### PR TITLE
🐛试图修复CodecUtil.NUMBER_PROVIDER_CODEC解码数据时的异常截断

### DIFF
--- a/src/main/java/dev/anvilcraft/lib/util/CodecUtil.java
+++ b/src/main/java/dev/anvilcraft/lib/util/CodecUtil.java
@@ -102,16 +102,17 @@ public abstract class CodecUtil {
     );
 
     public static final Codec<NumberProvider> NUMBER_PROVIDER_CODEC = Codec.either(
+        NumberProviders.CODEC,
         Codec.INT.xmap(
             ConstantValue::new,
             value -> Math.round(value.value())
-        ), NumberProviders.CODEC
+        )
     ).xmap(
         Either::unwrap, provider -> {
             if (!(provider instanceof ConstantValue(float value)) || value - Math.floor(value) >= 1E-5) {
-                return Either.right(provider);
+                return Either.left(provider);
             }
-            return Either.left((ConstantValue) provider);
+            return Either.right((ConstantValue) provider);
         }
     );
 


### PR DESCRIPTION
🐛试图修复CodecUtil.NUMBER_PROVIDER_CODEC解码数据时的异常截断
用于修复https://github.com/Anvil-Dev/AnvilCraft/issues/2952
