### PR TITLE
Registrum 添加数据组件谓词构建器支持

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,7 @@ permissions:
   actions: read
   packages: read
   pull-requests: write
+  issues: write
 
 jobs:
   codec:

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/AbstractRegistrum.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/AbstractRegistrum.java
@@ -41,6 +41,7 @@ import dev.anvilcraft.lib.v2.registrum.builders.MenuBuilder.ScreenFactory;
 import dev.anvilcraft.lib.v2.registrum.builders.MobEffectBuilder;
 import dev.anvilcraft.lib.v2.registrum.builders.NoConfigBuilder;
 import dev.anvilcraft.lib.v2.registrum.builders.SelfBuilder;
+import dev.anvilcraft.lib.v2.registrum.builders.data.DataComponentPredicateBuilder;
 import dev.anvilcraft.lib.v2.registrum.builders.self.PotionBuilder;
 import dev.anvilcraft.lib.v2.registrum.builders.self.SoundEventBuilder;
 import dev.anvilcraft.lib.v2.registrum.builders.data.AttachmentBuilder;
@@ -82,6 +83,7 @@ import net.minecraft.client.gui.screens.inventory.MenuAccess;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.core.component.predicates.DataComponentPredicate;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -1653,6 +1655,42 @@ public abstract class AbstractRegistrum<S extends AbstractRegistrum<S>> {
      * @author baka4n
      */
     public <E> DataComponentBuilder<E, S> dataComponent(String name) {
+        return dataComponent(self(), name);
+    }
+
+    /**
+     * Release under the MIT License. The full license text is available at <a href="https://opensource.org/license/mit">this</a>
+     *
+     * @author Gugle
+     */
+    public <E> DataComponentBuilder<E, S> dataComponent(String name, Class<E> clazz) {
+        return dataComponent(self(), name);
+    }
+
+    /**
+     * Release under the MIT License. The full license text is available at <a href="https://opensource.org/license/mit">this</a>
+     *
+     * @author Gugle
+     */
+    protected <E extends DataComponentPredicate, P> DataComponentPredicateBuilder<E, P> dataComponentPredicate(P parent, String name) {
+        return entry(name, callback -> new DataComponentPredicateBuilder<>(this, parent, name, callback));
+    }
+
+    /**
+     * Release under the MIT License. The full license text is available at <a href="https://opensource.org/license/mit">this</a>
+     *
+     * @author Gugle
+     */
+    public <E> DataComponentBuilder<E, S> dataComponentPredicate(String name) {
+        return dataComponent(self(), name);
+    }
+
+    /**
+     * Release under the MIT License. The full license text is available at <a href="https://opensource.org/license/mit">this</a>
+     *
+     * @author Gugle
+     */
+    public <E> DataComponentBuilder<E, S> dataComponentPredicate(String name, Class<E> clazz) {
         return dataComponent(self(), name);
     }
 

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/builders/data/DataComponentPredicateBuilder.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/builders/data/DataComponentPredicateBuilder.java
@@ -1,0 +1,50 @@
+package dev.anvilcraft.lib.v2.registrum.builders.data;
+
+import com.mojang.serialization.Codec;
+import dev.anvilcraft.lib.v2.registrum.AbstractRegistrum;
+import dev.anvilcraft.lib.v2.registrum.builders.AbstractBuilder;
+import dev.anvilcraft.lib.v2.registrum.builders.BuilderCallback;
+import dev.anvilcraft.lib.v2.registrum.util.entry.data.DataComponentPredicateEntry;
+import net.minecraft.core.component.predicates.DataComponentPredicate;
+import net.minecraft.core.registries.Registries;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import org.jspecify.annotations.Nullable;
+
+public class DataComponentPredicateBuilder<E extends DataComponentPredicate, P>
+    extends AbstractBuilder<DataComponentPredicate.Type<?>, DataComponentPredicate.Type<E>, P, DataComponentPredicateBuilder<E, P>> {
+    @Nullable Codec<E> codec;
+
+    public DataComponentPredicateBuilder(
+        AbstractRegistrum<?> owner,
+        P parent,
+        String name,
+        BuilderCallback callback
+    ) {
+        super(owner, parent, name, callback, Registries.DATA_COMPONENT_PREDICATE_TYPE);
+    }
+
+    public DataComponentPredicateBuilder<E, P> codec(Codec<E> codec) {
+        this.codec = codec;
+        return this;
+    }
+
+    @Override
+    protected DataComponentPredicate.Type<E> createEntry() {
+        if (this.codec == null) {
+            throw new IllegalStateException("Codec is not set");
+        }
+        return new DataComponentPredicate.ConcreteType<>(this.codec);
+    }
+
+    @Override
+    protected DataComponentPredicateEntry<E> createEntryWrapper(
+        DeferredHolder<DataComponentPredicate.Type<?>, DataComponentPredicate.Type<E>> delegate
+    ) {
+        return new DataComponentPredicateEntry<>(this.getOwner(), delegate);
+    }
+
+    @Override
+    public DataComponentPredicateEntry<E> register() {
+        return (DataComponentPredicateEntry<E>) super.register();
+    }
+}

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/entry/data/DataComponentPredicateEntry.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/entry/data/DataComponentPredicateEntry.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * Original work copyright (c) 2026 Anvil-Dev (AnvilLib-Registrum)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package dev.anvilcraft.lib.v2.registrum.util.entry.data;
+
+import dev.anvilcraft.lib.v2.registrum.AbstractRegistrum;
+import dev.anvilcraft.lib.v2.registrum.util.entry.RegistryEntry;
+import net.minecraft.core.component.predicates.DataComponentPredicate;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+public class DataComponentPredicateEntry<E extends DataComponentPredicate>
+    extends RegistryEntry<DataComponentPredicate.Type<?>, DataComponentPredicate.Type<E>> {
+
+    public DataComponentPredicateEntry(
+        AbstractRegistrum<?> owner,
+        DeferredHolder<DataComponentPredicate.Type<?>, DataComponentPredicate.Type<E>> key
+    ) {
+        super(owner, key);
+    }
+
+    public static <E extends DataComponentPredicate> DataComponentPredicateEntry<E> cast(
+        RegistryEntry<DataComponentPredicate.Type<?>, DataComponentPredicate.Type<E>> entry
+    ) {
+        return RegistryEntry.cast(DataComponentPredicateEntry.class, entry);
+    }
+}


### PR DESCRIPTION
- 引入 DataComponentPredicateBuilder 类用于构建数据组件谓词
- 添加 DataComponentPredicateEntry 工具类用于注册表条目管理
- 在 AbstractRegistrum 中新增 dataComponentPredicate 相关方法
- 实现数据组件谓词类型的编解码器支持
- 添加完整的 JavaDoc 注释和 MIT 许可证声明