### PR TITLE
Add drawAdditionalCallback to StructurePipRenderingState

### DIFF
--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/GuiRenderExtras.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/GuiRenderExtras.java
@@ -13,7 +13,6 @@ import net.minecraft.client.gui.render.TextureSetup;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
-import net.minecraft.client.renderer.state.gui.BlitRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
@@ -299,7 +298,7 @@ public class GuiRenderExtras {
                 poseStack.last().copy(),
                 guiGraphicsExtractor.pose().get(new Matrix3x2f()),
                 guiGraphicsExtractor.peekScissorStack(),
-                null
+                (BiConsumer<SubmitNodeCollector, PoseStack>) null
             )
         );
     }
@@ -333,7 +332,7 @@ public class GuiRenderExtras {
                 pose3D,
                 guiGraphicsExtractor.pose().get(new Matrix3x2f()),
                 guiGraphicsExtractor.peekScissorStack(),
-                null
+                (BiConsumer<SubmitNodeCollector, PoseStack>)null
             )
         );
     }

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/GuiRenderExtras.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/GuiRenderExtras.java
@@ -11,6 +11,7 @@ import dev.anvilcraft.lib.v2.rendering.gui.state.StructurePipRenderingState;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.render.TextureSetup;
 import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.state.gui.BlitRenderState;
 import net.minecraft.core.BlockPos;
@@ -19,6 +20,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Matrix3x2f;
 import org.jspecify.annotations.Nullable;
 
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 public class GuiRenderExtras {
@@ -296,7 +298,8 @@ public class GuiRenderExtras {
                 glitched,
                 poseStack.last().copy(),
                 guiGraphicsExtractor.pose().get(new Matrix3x2f()),
-                guiGraphicsExtractor.peekScissorStack()
+                guiGraphicsExtractor.peekScissorStack(),
+                null
             )
         );
     }
@@ -329,7 +332,8 @@ public class GuiRenderExtras {
                 glitched,
                 pose3D,
                 guiGraphicsExtractor.pose().get(new Matrix3x2f()),
-                guiGraphicsExtractor.peekScissorStack()
+                guiGraphicsExtractor.peekScissorStack(),
+                null
             )
         );
     }
@@ -358,6 +362,105 @@ public class GuiRenderExtras {
             false,
             false,
             pose3D
+        );
+    }
+
+    public static void submitStructure(
+        GuiGraphicsExtractor guiGraphicsExtractor,
+        BlockAndTintGetter structureAccess,
+        BlockPos startPos,
+        BlockPos endPos,
+        float x0,
+        float y0,
+        float x1,
+        float y1,
+        float scale,
+        boolean ambientOcclusion,
+        boolean glitched,
+        PoseStack poseStack,
+        BiConsumer<SubmitNodeCollector, PoseStack> drawAdditionalCallback
+    ) {
+        guiGraphicsExtractor.submitPictureInPictureRenderState(
+            new StructurePipRenderingState(
+                structureAccess,
+                startPos,
+                endPos,
+                (int) x0,
+                (int) y0,
+                (int) x1,
+                (int) y1,
+                scale,
+                ambientOcclusion,
+                glitched,
+                poseStack.last().copy(),
+                guiGraphicsExtractor.pose().get(new Matrix3x2f()),
+                guiGraphicsExtractor.peekScissorStack(),
+                drawAdditionalCallback
+            )
+        );
+    }
+
+    public static void submitStructure(
+        GuiGraphicsExtractor guiGraphicsExtractor,
+        BlockAndTintGetter structureAccess,
+        BlockPos startPos,
+        BlockPos endPos,
+        float x0,
+        float y0,
+        float x1,
+        float y1,
+        float scale,
+        boolean ambientOcclusion,
+        boolean glitched,
+        PoseStack.Pose pose3D,
+        BiConsumer<SubmitNodeCollector, PoseStack> drawAdditionalCallback
+    ) {
+        guiGraphicsExtractor.submitPictureInPictureRenderState(
+            new StructurePipRenderingState(
+                structureAccess,
+                startPos,
+                endPos,
+                (int) x0,
+                (int) y0,
+                (int) x1,
+                (int) y1,
+                scale,
+                ambientOcclusion,
+                glitched,
+                pose3D,
+                guiGraphicsExtractor.pose().get(new Matrix3x2f()),
+                guiGraphicsExtractor.peekScissorStack(),
+                drawAdditionalCallback
+            )
+        );
+    }
+
+    public static void submitStructure(
+        GuiGraphicsExtractor guiGraphicsExtractor,
+        BlockAndTintGetter structureAccess,
+        BlockPos startPos,
+        BlockPos endPos,
+        float x0,
+        float y0,
+        float x1,
+        float y1,
+        PoseStack.Pose pose3D,
+        BiConsumer<SubmitNodeCollector, PoseStack> drawAdditionalCallback
+    ) {
+        submitStructure(
+            guiGraphicsExtractor,
+            structureAccess,
+            startPos,
+            endPos,
+            x0,
+            y0,
+            x1,
+            y1,
+            32.0f,
+            false,
+            false,
+            pose3D,
+            drawAdditionalCallback
         );
     }
 }

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/StructurePipRenderer.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/StructurePipRenderer.java
@@ -147,25 +147,25 @@ public class StructurePipRenderer extends PictureInPictureRenderer<StructurePipR
         }
 
         bufferSource.endBatch();
+
+        RenderBuffers renderBuffers = minecraft.renderBuffers();
+        SubmitNodeStorage submitNodeStorage = new SubmitNodeStorage();
+        GameRenderer gameRenderer = minecraft.gameRenderer;
+        FeatureRenderDispatcher frd = new FeatureRenderDispatcher(
+            submitNodeStorage,
+            minecraft.getModelManager(),
+            renderBuffers.bufferSource(),
+            minecraft.getAtlasManager(),
+            renderBuffers.outlineBufferSource(),
+            renderBuffers.crumblingBufferSource(),
+            minecraft.font,
+            gameRenderer.getGameRenderState()
+        );
         for (BlockPos blockPos : BlockPos.betweenClosed(renderState.startPos(), renderState.endPos())) {
             BlockEntity blockEntity = level.getBlockEntity(blockPos);
             if (blockEntity == null) continue;
             BlockEntityRenderer blockEntityRenderer = minecraft.getBlockEntityRenderDispatcher().getRenderer(blockEntity);
             if (blockEntityRenderer == null) continue;
-
-            RenderBuffers renderBuffers = minecraft.renderBuffers();
-            SubmitNodeStorage submitNodeStorage = new SubmitNodeStorage();
-            GameRenderer gameRenderer = minecraft.gameRenderer;
-            FeatureRenderDispatcher frd = new FeatureRenderDispatcher(
-                submitNodeStorage,
-                minecraft.getModelManager(),
-                renderBuffers.bufferSource(),
-                minecraft.getAtlasManager(),
-                renderBuffers.outlineBufferSource(),
-                renderBuffers.crumblingBufferSource(),
-                minecraft.font,
-                gameRenderer.getGameRenderState()
-            );
             poseStack.pushPose();
             poseStack.translate(blockPos.getX(), blockPos.getY(), blockPos.getZ());
             BlockEntityRenderState blockEntityRenderState = blockEntityRenderer.createRenderState();
@@ -182,12 +182,19 @@ public class StructurePipRenderer extends PictureInPictureRenderer<StructurePipR
                 submitNodeStorage,
                 gameRenderer.getGameRenderState().levelRenderState.cameraRenderState
             );
-            frd.renderAllFeatures();
             poseStack.popPose();
         }
+        if (renderState.drawAdditionalCallback() != null) {
+            renderState.drawAdditionalCallback().accept(submitNodeStorage, poseStack);
+        }
+        frd.renderAllFeatures();
+        bufferSource.endBatch();
 
         poseStack.popPose();
         poseStack.popPose();
+        if (!poseStack.isEmpty()) {
+            throw new IllegalStateException("Pose stack not empty");
+        }
         if (renderState.glitched()) {
             applyGlitchEffect(width, height);
         }

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/StructurePipRenderingState.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/StructurePipRenderingState.java
@@ -2,12 +2,15 @@ package dev.anvilcraft.lib.v2.rendering.gui.state;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.state.gui.pip.PictureInPictureRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import org.joml.Matrix3x2f;
 import org.jspecify.annotations.Nullable;
+
+import java.util.function.BiConsumer;
 
 public record StructurePipRenderingState (
     BlockAndTintGetter structureAccess,
@@ -23,7 +26,8 @@ public record StructurePipRenderingState (
     PoseStack.Pose pose3D,
     Matrix3x2f pose,
     @Nullable ScreenRectangle scissorArea,
-    @Nullable ScreenRectangle bounds
+    @Nullable ScreenRectangle bounds,
+    @Nullable BiConsumer<SubmitNodeCollector, PoseStack> drawAdditionalCallback
 ) implements PictureInPictureRenderState {
 
     public StructurePipRenderingState(
@@ -39,7 +43,8 @@ public record StructurePipRenderingState (
         boolean glitched,
         PoseStack.Pose pose3D,
         Matrix3x2f pose,
-        @Nullable ScreenRectangle scissorArea
+        @Nullable ScreenRectangle scissorArea,
+        @Nullable BiConsumer<SubmitNodeCollector, PoseStack> drawAdditionalCallback
     ){
         this(
             structureAccess,
@@ -55,7 +60,8 @@ public record StructurePipRenderingState (
             pose3D,
             pose,
             scissorArea,
-            PictureInPictureRenderState.getBounds(Mth.floor(x0), Mth.floor(y0), Mth.floor(x1), Mth.floor(y1), scissorArea)
+            PictureInPictureRenderState.getBounds(Mth.floor(x0), Mth.floor(y0), Mth.floor(x1), Mth.floor(y1), scissorArea),
+            drawAdditionalCallback
         );
     }
 }

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/StructurePipRenderingState.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/StructurePipRenderingState.java
@@ -7,11 +7,13 @@ import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.state.gui.pip.PictureInPictureRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
+import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix3x2f;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.BiConsumer;
 
+@ApiStatus.Internal
 public record StructurePipRenderingState (
     BlockAndTintGetter structureAccess,
     BlockPos startPos,
@@ -45,7 +47,7 @@ public record StructurePipRenderingState (
         Matrix3x2f pose,
         @Nullable ScreenRectangle scissorArea,
         @Nullable BiConsumer<SubmitNodeCollector, PoseStack> drawAdditionalCallback
-    ){
+    ) {
         this(
             structureAccess,
             startPos,
@@ -62,6 +64,75 @@ public record StructurePipRenderingState (
             scissorArea,
             PictureInPictureRenderState.getBounds(Mth.floor(x0), Mth.floor(y0), Mth.floor(x1), Mth.floor(y1), scissorArea),
             drawAdditionalCallback
+        );
+    }
+
+    public StructurePipRenderingState(
+        BlockAndTintGetter structureAccess,
+        BlockPos startPos,
+        BlockPos endPos,
+        int x0,
+        int y0,
+        int x1,
+        int y1,
+        float scale,
+        boolean ambientOcclusion,
+        boolean glitched,
+        PoseStack.Pose pose3D,
+        Matrix3x2f pose,
+        @Nullable ScreenRectangle scissorArea
+    ) {
+        this(
+            structureAccess,
+            startPos,
+            endPos,
+            x0,
+            y0,
+            x1,
+            y1,
+            scale,
+            ambientOcclusion,
+            glitched,
+            pose3D,
+            pose,
+            scissorArea,
+            PictureInPictureRenderState.getBounds(Mth.floor(x0), Mth.floor(y0), Mth.floor(x1), Mth.floor(y1), scissorArea),
+            null
+        );
+    }
+
+    public StructurePipRenderingState(
+        BlockAndTintGetter structureAccess,
+        BlockPos startPos,
+        BlockPos endPos,
+        int x0,
+        int y0,
+        int x1,
+        int y1,
+        float scale,
+        boolean ambientOcclusion,
+        boolean glitched,
+        PoseStack.Pose pose3D,
+        Matrix3x2f pose,
+        @Nullable ScreenRectangle scissorArea,
+        @Nullable ScreenRectangle bounds
+    ) {
+        this(
+            structureAccess,
+            startPos,
+            endPos,
+            x0,
+            y0,
+            x1,
+            y1,
+            scale,
+            ambientOcclusion,
+            glitched,
+            pose3D,
+            pose,
+            scissorArea,
+            bounds,
+            null
         );
     }
 }


### PR DESCRIPTION
## Add Support for Additional Draw Callbacks in Structure Picture-in-Picture Rendering

### What's Changed

This PR adds support for custom drawing callbacks in the structure picture-in-picture (PiP) rendering system, enabling more flexible rendering of additional elements during structure visualization.

### Changes Summary

1. **GuiRenderExtras.java**
   - Added new overloaded `submitStructure()` methods that accept a `BiConsumer<SubmitNodeCollector, PoseStack>` callback parameter for drawing additional elements
   - Updated existing `submitStructure()` calls to pass `null` as the new callback parameter for backward compatibility
   - Added import for `BiConsumer` and `SubmitNodeCollector`

2. **StructurePipRenderer.java**
   - Moved `RenderBuffers`, `SubmitNodeStorage`, `GameRenderer`, and `FeatureRenderDispatcher` initialization outside the loop to improve performance
   - Added callback invocation after block entities are rendered but before feature rendering
   - Added pose stack validation to ensure proper pose stack state after rendering
   - Improved buffer management with additional `endBatch()` call

3. **StructurePipRenderingState.java**
   - Extended the record to include `drawAdditionalCallback` field
   - Updated both constructors to accept and pass through the callback parameter
   - Added necessary imports for `BiConsumer` and `SubmitNodeCollector`

### Benefits

- **Extensibility**: Allows custom rendering logic to be injected into the structure PiP rendering pipeline
- **Performance**: Optimized render state initialization by moving it outside the block entity loop
- **Robustness**: Added pose stack validation to catch rendering state errors

### Type of Change

- ✨ Feature addition
- 🔧 Performance improvement
- 🛡️ Code robustness enhancement