### PR TITLE
chore(workflow): 更新 PR 评论工作流配置

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -453,12 +453,13 @@ jobs:
         uses: peter-evans/find-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: github-actions[bot]
+          comment-author: anvil-craft
           body-includes: Roseau API Breaking Change Report
 
       - name: Create or update PR comment
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ secrets.PAT_TOKEN }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: /tmp/roseau-body.md


### PR DESCRIPTION
- 将评论作者从 github-actions[bot] 更改为 anvil-craft
- 为 create-or-update-comment 步骤添加 PAT_TOKEN 认证
- 确保 PR 评论功能正常运行