### PR TITLE
fix(workflow): 为玫瑰报告添加GitHub令牌

### DIFF
--- a/.github/workflows/roseau_comment.yml
+++ b/.github/workflows/roseau_comment.yml
@@ -23,6 +23,7 @@ jobs:
           pattern: roseau-*
           path: roseau-reports
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.PAT_TOKEN }}
 
       - name: Checkout repo (needed for gh CLI)
         uses: actions/checkout@v4


### PR DESCRIPTION
- 在roseau_comment工作流中添加PAT_TOKEN以支持gh CLI操作
- 修复了缺少认证令牌导致的工作流执行问题