### PR TITLE
refactor(registrum): 更新数据组件谓词方法的泛型类型定义

### DIFF
--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/AbstractRegistrum.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/AbstractRegistrum.java
@@ -1681,8 +1681,9 @@ public abstract class AbstractRegistrum<S extends AbstractRegistrum<S>> {
      *
      * @author Gugle
      */
-    public <E> DataComponentBuilder<E, S> dataComponentPredicate(String name) {
-        return dataComponent(self(), name);
+    public <E extends DataComponentPredicate, P> DataComponentPredicateBuilder<E, P> dataComponentPredicate(String name) {
+        //noinspection unchecked
+        return (DataComponentPredicateBuilder<E, P>) dataComponentPredicate(self(), name);
     }
 
     /**
@@ -1690,8 +1691,9 @@ public abstract class AbstractRegistrum<S extends AbstractRegistrum<S>> {
      *
      * @author Gugle
      */
-    public <E> DataComponentBuilder<E, S> dataComponentPredicate(String name, Class<E> clazz) {
-        return dataComponent(self(), name);
+    public <E extends DataComponentPredicate, P> DataComponentPredicateBuilder<E, P> dataComponentPredicate(String name, Class<E> clazz) {
+        //noinspection unchecked
+        return (DataComponentPredicateBuilder<E, P>) dataComponentPredicate(self(), name);
     }
 
     // Biome Modifier


### PR DESCRIPTION
- 修改 dataComponentPredicate 方法的返回类型为 DataComponentPredicateBuilder
- 添加泛型约束 E extends DataComponentPredicate
- 添加类型参数 P 用于构建器模式
- 在类型转换处添加 unchecked 注解抑制警告
- 确保方法签名与实际实现保持一致