### PR TITLE
ci: publish Yukkuri before aggregate module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,31 @@ jobs:
       signing_key: ${{ secrets.SIGNING_KEY }}
       signing_public_key: ${{ secrets.SIGNING_PUBLIC_KEY }}
       signing_password: ${{ secrets.SIGNING_PASSWORD }}
+  yukkuri:
+    uses: ./.github/workflows/build_and_test.yml
+    with:
+      module: yukkuri
+      module_id: anvillib-yukkuri
+      mod_id: anvillib_yukkuri
+      ci_build: true
+      pr_build: false
+    secrets:
+      maven_url: ${{ secrets.MAVEN_URL }}
+      maven_user: ${{ secrets.MAVEN_USER }}
+      maven_pass: ${{ secrets.MAVEN_PASS }}
+  yukkuri-maven-central-deploy:
+    uses: ./.github/workflows/publish_maven_central.yml
+    needs:
+      - yukkuri
+    with:
+      module: yukkuri
+      module_id: anvillib-yukkuri
+    secrets:
+      maven_central_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      maven_central_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      signing_key: ${{ secrets.SIGNING_KEY }}
+      signing_public_key: ${{ secrets.SIGNING_PUBLIC_KEY }}
+      signing_password: ${{ secrets.SIGNING_PASSWORD }}
   main:
     needs:
       - config
@@ -291,6 +316,7 @@ jobs:
       - registrum
       - util
       - wheel
+      - yukkuri
     uses: ./.github/workflows/build_and_test.yml
     with:
       module: main


### PR DESCRIPTION
## Summary
- add Yukkuri build and Maven publication jobs
- publish Yukkuri to Maven Central through the existing reusable workflow
- make the aggregate AnvilLib job wait for Yukkuri publication

## Verification
- built the Yukkuri module locally
- built the aggregate AnvilLib module locally
- confirmed the aggregate JAR contains exactly one nested Yukkuri JAR

This fixes CI run 495, where the aggregate build could not resolve the newly added Yukkuri module.