### PR TITLE
fix: declare CurseForge environments

### DIFF
--- a/module.main/build.gradle
+++ b/module.main/build.gradle
@@ -321,6 +321,8 @@ publishMods {
         accessToken = System.getenv("CURSEFORGE_TOKEN")
         projectId = "1484302"
         minecraftVersions.add(libs.versions.minecraft.get())
+        clientRequired = true
+        serverRequired = true
     }
 
     modrinth {


### PR DESCRIPTION
## Summary
- mark the aggregate AnvilLib upload as available on both client and server
- satisfy CurseForge's required environment-version selection

## Verification
- verified the Mod Publish Plugin 1.1.0 DSL from its published sources
- configured the aggregate Gradle project successfully

Run 496 completed its build, GameTest, and project-Maven publication, but this post-build CurseForge validation error prevented the aggregate Maven Central job from running.