### PR TITLE
fix(rendering): stabilize bloom and compute support

### DIFF
--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/ALRPostEffects.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/ALRPostEffects.java
@@ -4,6 +4,7 @@ import dev.anvilcraft.lib.v2.rendering.bloom.BloomPostEffect;
 import dev.anvilcraft.lib.v2.rendering.event.MainTargetResizeEvent;
 import dev.anvilcraft.lib.v2.rendering.glitch.GlitchPostEffect;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
@@ -11,6 +12,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import org.joml.Matrix4fc;
 
+@Slf4j
 @EventBusSubscriber
 public class ALRPostEffects {
     @Getter
@@ -24,19 +26,23 @@ public class ALRPostEffects {
     }
 
     public static void runBloomDraws(Matrix4fc mvMat) {
-        Minecraft minecraft = Minecraft.getInstance();
-        RenderBuffers renderBuffers = minecraft.renderBuffers();
-        FeatureRenderDispatcher frd = new FeatureRenderDispatcher(
-            bloomPostEffect.getSubmitNodeStorage(),
-            minecraft.getModelManager(),
-            renderBuffers.bufferSource(),
-            minecraft.getAtlasManager(),
-            renderBuffers.outlineBufferSource(),
-            renderBuffers.crumblingBufferSource(),
-            minecraft.font,
-            minecraft.gameRenderer.getGameRenderState()
-        );
-        bloomPostEffect.runBloomDraws(mvMat, frd);
+        try {
+            Minecraft minecraft = Minecraft.getInstance();
+            RenderBuffers renderBuffers = minecraft.renderBuffers();
+            FeatureRenderDispatcher frd = new FeatureRenderDispatcher(
+                bloomPostEffect.getSubmitNodeStorage(),
+                minecraft.getModelManager(),
+                renderBuffers.bufferSource(),
+                minecraft.getAtlasManager(),
+                renderBuffers.outlineBufferSource(),
+                renderBuffers.crumblingBufferSource(),
+                minecraft.font,
+                minecraft.gameRenderer.getGameRenderState()
+            );
+            bloomPostEffect.runBloomDraws(mvMat, frd);
+        } catch (Exception e) {
+            log.error("runBloomDraws boom!", e);
+        }
     }
 
     @SubscribeEvent

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/AnvilLibRendering.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/AnvilLibRendering.java
@@ -6,6 +6,7 @@ import dev.anvilcraft.lib.v2.rendering.gui.renderer.BlockStatePipRenderer;
 import dev.anvilcraft.lib.v2.rendering.gui.renderer.StructurePipRenderer;
 import dev.anvilcraft.lib.v2.rendering.gui.state.BlockStatePipRenderingState;
 import dev.anvilcraft.lib.v2.rendering.gui.state.StructurePipRenderingState;
+import lombok.extern.slf4j.Slf4j;
 import net.minecraft.resources.Identifier;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
@@ -17,6 +18,7 @@ import net.neoforged.neoforge.client.event.RegisterPictureInPictureRenderersEven
 import net.neoforged.neoforge.client.event.RenderFrameEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 
+@Slf4j
 @Mod(value = AnvilLibRendering.MODID, dist = Dist.CLIENT)
 @EventBusSubscriber(Dist.CLIENT)
 public class AnvilLibRendering {
@@ -70,7 +72,12 @@ public class AnvilLibRendering {
 
     @SubscribeEvent
     public static void on(RenderLevelStageEvent.AfterLevel event) {
-        ALRPostEffects.getBloomPostEffect().process();
+        try {
+            ALRPostEffects.getBloomPostEffect().process();
+        } catch (Exception e) {
+            log.error("ALRPostEffects BloomPostEffect", e);
+        }
+
     }
 
     @SubscribeEvent

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/bloom/BloomPostEffect.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/bloom/BloomPostEffect.java
@@ -2,10 +2,8 @@ package dev.anvilcraft.lib.v2.rendering.bloom;
 
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.pipeline.MainTarget;
-import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.pipeline.TextureTarget;
-import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
@@ -21,7 +19,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import dev.anvilcraft.lib.v2.rendering.ALRPipelines;
-import dev.anvilcraft.lib.v2.rendering.AnvilLibRendering;
 import dev.anvilcraft.lib.v2.rendering.foundation.buffers.layout.BufferLayout;
 import dev.anvilcraft.lib.v2.rendering.foundation.compound.CompoundSubmitNodeStorage;
 import dev.anvilcraft.lib.v2.rendering.foundation.compound.DirtyTracked;
@@ -30,12 +27,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
-import net.minecraft.resources.Identifier;
-import net.minecraft.resources.ResourceKey;
-import net.neoforged.neoforge.client.pipeline.PipelineModifier;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
-import org.joml.Vector2f;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -168,8 +161,19 @@ public class BloomPostEffect implements DirtyTracked {
     }
 
     public void beginBloomDraw() {
+        RenderTarget mainRenderTarget = Minecraft.getInstance().getMainRenderTarget();
+
+        this.guardSize(mainRenderTarget);
+
+        bloomInputTarget.copyDepthFrom(mainRenderTarget);
+
         setupOutputOverride();
-        bloomInputTarget.copyDepthFrom(Minecraft.getInstance().getMainRenderTarget());
+    }
+
+    private void guardSize(RenderTarget mainRenderTarget) {
+        if (mainRenderTarget.width != this.bloomInputTarget.width || mainRenderTarget.height != this.bloomInputTarget.height) {
+            this.resize(mainRenderTarget.width, mainRenderTarget.height);
+        }
     }
 
     public void endBloomDraw() {
@@ -190,25 +194,32 @@ public class BloomPostEffect implements DirtyTracked {
 
     public void runBloomDraws(Matrix4fc modelViewMatrix, FeatureRenderDispatcher featureRenderDispatcher) {
         if (!dirty) return;
-        beginBloomDraw();
+
         PoseStack poseStack = new PoseStack();
         RenderSystem.getModelViewStack().pushMatrix();
         RenderSystem.getModelViewStack().set(modelViewMatrix);
-        if (!bloomCalls.isEmpty()) {
-            for (BloomRenderCallback bloomCall : bloomCalls) {
-                bloomCall.render(featureRenderDispatcher.getSubmitNodeStorage(), poseStack);
+        try {
+            beginBloomDraw();
+            if (!bloomCalls.isEmpty()) {
+                for (BloomRenderCallback bloomCall : bloomCalls) {
+                    bloomCall.render(featureRenderDispatcher.getSubmitNodeStorage(), poseStack);
+                }
             }
+            featureRenderDispatcher.renderAllFeatures();
+            Minecraft.getInstance().renderBuffers().bufferSource().endBatch();
+        } finally {
+            endBloomDraw();
+            RenderSystem.getModelViewStack().popMatrix();
         }
-        featureRenderDispatcher.renderAllFeatures();
-        Minecraft.getInstance().renderBuffers().bufferSource().endBatch();
-        RenderSystem.getModelViewStack().popMatrix();
-        endBloomDraw();
     }
 
     @SuppressWarnings("DataFlowIssue")
     public void process() {
         if (!dirty) return;
         CommandEncoder commandEncoder = device.createCommandEncoder();
+        RenderTarget mainRenderTarget = Minecraft.getInstance().getMainRenderTarget();
+
+        this.guardSize(mainRenderTarget);
 
         transformsUbo.upload(commandEncoder, transformUBO.slice());
 
@@ -216,13 +227,13 @@ public class BloomPostEffect implements DirtyTracked {
         this.doUpSample(commandEncoder);
 
         // backup depth texture
-        bloomInputTarget.copyDepthFrom(Minecraft.getInstance().getMainRenderTarget());
+        bloomInputTarget.copyDepthFrom(mainRenderTarget);
 
         clearColorAndDepth(bloomTempTarget, 0);
-        applyBloom(commandEncoder, this.upsampleTargets[0], Minecraft.getInstance().getMainRenderTarget().getColorTextureView(), bloomTempTarget);
+        applyBloom(commandEncoder, this.upsampleTargets[0], mainRenderTarget.getColorTextureView(), bloomTempTarget);
         commandEncoder.copyTextureToTexture(
             bloomTempTarget.getColorTexture(),
-            Minecraft.getInstance().getMainRenderTarget().getColorTexture(),
+            mainRenderTarget.getColorTexture(),
             0,
             0,
             0,
@@ -231,7 +242,7 @@ public class BloomPostEffect implements DirtyTracked {
             width,
             height
         );
-        Minecraft.getInstance().getMainRenderTarget().copyDepthFrom(bloomInputTarget);
+        mainRenderTarget.copyDepthFrom(bloomInputTarget);
     }
 
     @SuppressWarnings("DataFlowIssue")

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/AnvilLibTestClient.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/AnvilLibTestClient.java
@@ -3,6 +3,7 @@ package dev.anvilcraft.lib.v2.test.client;
 import com.mojang.brigadier.arguments.FloatArgumentType;
 import dev.anvilcraft.lib.v2.rendering.cachedber.renderer.CachedBlockEntityRenderDispatcher;
 import dev.anvilcraft.lib.v2.rendering.event.MainTargetResizeEvent;
+import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.ALRComputeCapabilities;
 import dev.anvilcraft.lib.v2.test.AnvilLibTest;
 import dev.anvilcraft.lib.v2.test.all.TestTiles;
 import dev.anvilcraft.lib.v2.test.client.cber.TestCachedRenderer;
@@ -49,11 +50,17 @@ public class AnvilLibTestClient {
 
     @SubscribeEvent
     public static void on(MainTargetResizeEvent event) {
+        if (!ALRComputeCapabilities.isComputeSupported()) {
+            return;
+        }
         ComputeSupport.INSTANCE.resize(event.getNewWidth(), event.getNewHeight());
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void on(RenderLevelStageEvent.AfterLevel level) {
+        if (!ALRComputeCapabilities.isComputeSupported()) {
+            return;
+        }
         ComputeSupport.INSTANCE.computeBlur();
     }
 

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/compute/ComputeSupport.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/compute/ComputeSupport.java
@@ -31,10 +31,20 @@ import java.util.List;
 import java.util.OptionalDouble;
 
 public class ComputeSupport {
-    public static final ComputeSupport INSTANCE = new ComputeSupport();
+    public static final ComputeSupport INSTANCE;
     public static final float[] UNSUPPORTED = {};
     @Getter
     private final GpuDevice device = RenderSystem.getDevice();
+
+    static {
+        ComputeSupport instance;
+        if (ALRComputeCapabilities.isComputeSupported()) {
+            instance = new ComputeSupport();
+        } else {
+            instance = null;
+        }
+        INSTANCE = instance;
+    }
 
     private final GpuBuffer addInputSSBO = device.createBuffer(
         () -> "Test Compute Input SSBO",
@@ -144,7 +154,7 @@ public class ComputeSupport {
         ByteBuffer counterData = mappedCounterBuffer.data();
 
         int anInt = counterData.getInt();
-        if (anInt != input.length){
+        if (anInt != input.length) {
             System.out.printf("Compute counter does not match with input size: %d/%d%n", anInt, input.length);
         }
         return result;
@@ -239,5 +249,6 @@ public class ComputeSupport {
 
 
     public static void init() {
+
     }
 }

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/screen/GuiTestScreen.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/screen/GuiTestScreen.java
@@ -223,6 +223,10 @@ public class GuiTestScreen extends Screen {
             ex.printStackTrace();
         }
 
+        if (!ALRComputeCapabilities.isComputeSupported()) {
+            return;
+        }
+
         GpuSampler sampler = ComputeSupport.INSTANCE.getTheSampler();
         int scaledWidth = Minecraft.getInstance().getWindow().getGuiScaledWidth();
         int scaledHeight = Minecraft.getInstance().getWindow().getGuiScaledHeight();

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/mixin/MinecraftMixin.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/mixin/MinecraftMixin.java
@@ -29,6 +29,9 @@ public class MinecraftMixin {
         at = @At("RETURN")
     )
     private void onCreateInstance(GameConfig gameConfig, CallbackInfo ci) {
+        if (ALRComputeCapabilities.isComputeSupported()) {
+            return;
+        }
         ComputeSupport.init();
     }
 


### PR DESCRIPTION
## Summary

- keep bloom render targets synchronized with the main target size
- restore render state reliably and log bloom failures
- guard compute test paths on unsupported devices

## Verification

- `sh gradlew :anvillib-rendering-neoforge-26.1:compileJava :anvillib-test-neoforge-26.1:compileJava`