### PR TITLE
chore(annotations): 添加 ApiStatus.Internal 注解到内部接口和类

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -121,7 +121,6 @@ jobs:
           MAVEN_URL: ${{ secrets.maven_url }}
           MAVEN_USERNAME: ${{ secrets.maven_user }}
           MAVEN_PASSWORD: ${{ secrets.maven_pass }}
-        continue-on-error: true
 
       - name: capture maven artifacts
         uses: actions/upload-artifact@v7
@@ -148,3 +147,4 @@ jobs:
         env:
           CURSEFORGE_TOKEN: ${{ secrets.curseforge_token }}
           MODRINTH_TOKEN: ${{ secrets.modrinth_token }}
+        continue-on-error: true

--- a/module.collision/src/main/java/dev/anvilcraft/lib/v2/collision/CollisionTest.java
+++ b/module.collision/src/main/java/dev/anvilcraft/lib/v2/collision/CollisionTest.java
@@ -4,11 +4,13 @@ import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
+import org.jetbrains.annotations.ApiStatus;
 
 import static dev.anvilcraft.lib.v2.collision.AnvilLibCollision.intersectsAABBTriangle;
 import static dev.anvilcraft.lib.v2.collision.AnvilLibCollision.overlapOnAxis;
 import static dev.anvilcraft.lib.v2.collision.AnvilLibCollision.sweptCollisionAABBTriangle;
 
+@ApiStatus.Internal
 public class CollisionTest {
 
     static void main() {

--- a/module.config/src/main/java/dev/anvilcraft/lib/v2/config/BoundedDiscrete.java
+++ b/module.config/src/main/java/dev/anvilcraft/lib/v2/config/BoundedDiscrete.java
@@ -1,5 +1,7 @@
 package dev.anvilcraft.lib.v2.config;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,6 +14,7 @@ public @interface BoundedDiscrete {
 
     double max() default Double.POSITIVE_INFINITY;
 
+    @ApiStatus.Internal
     class Util {
         public static int minInt(BoundedDiscrete annotation) {
             if (annotation.min() == Double.NEGATIVE_INFINITY) return Integer.MIN_VALUE;

--- a/module.config/src/main/java/dev/anvilcraft/lib/v2/config/ConfigField.java
+++ b/module.config/src/main/java/dev/anvilcraft/lib/v2/config/ConfigField.java
@@ -1,11 +1,13 @@
 package dev.anvilcraft.lib.v2.config;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
+import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Field;
 
+@ApiStatus.Internal
 public record ConfigField(
     Object object,
     Field field,

--- a/module.config/src/main/java/dev/anvilcraft/lib/v2/config/ConfigManager.java
+++ b/module.config/src/main/java/dev/anvilcraft/lib/v2/config/ConfigManager.java
@@ -15,6 +15,7 @@ import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.common.ModConfigSpec;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -58,6 +59,7 @@ public class ConfigManager {
         return config;
     }
 
+    @ApiStatus.Internal
     public <T> T register(T configObj) {
         Class<?> configClass = configObj.getClass();
         ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
@@ -78,10 +80,12 @@ public class ConfigManager {
         return configObj;
     }
 
+    @ApiStatus.Internal
     public void register(IEventBus bus) {
         bus.register(this);
     }
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public void onModConstruct(FMLConstructModEvent event) {
         ModContainer container = ModLoadingContext.get().getActiveContainer();
@@ -95,11 +99,13 @@ public class ConfigManager {
         }
     }
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public void loading(ModConfigEvent event) {
         this.configSpecMap.values().forEach(ConfigRecord::load);
     }
 
+    @ApiStatus.Internal
     public void registerScreen(ModContainer container) {
         container.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
     }
@@ -135,6 +141,7 @@ public class ConfigManager {
         }
     }
 
+    @ApiStatus.Internal
     public static ModConfigSpec.ConfigValue<?> define(ModConfigSpec.Builder builder, String name, Field field, Object object) {
         return switch (object) {
             case Number num -> ConfigManager.defineInRange(builder, name, field, num);
@@ -145,10 +152,12 @@ public class ConfigManager {
     }
 
     @SuppressWarnings("unchecked")
+    @ApiStatus.Internal
     public static <E extends Enum<E>> ModConfigSpec.EnumValue<E> defineEnum(ModConfigSpec.Builder builder, String name, Enum<?> enumValue) {
         return builder.defineEnum(name, (E) enumValue);
     }
 
+    @ApiStatus.Internal
     public static ModConfigSpec.ConfigValue<?> defineInRange(ModConfigSpec.Builder builder, String name, Field field, Number number) {
         if (field.isAnnotationPresent(BoundedDiscrete.class)) {
             BoundedDiscrete discrete = field.getAnnotation(BoundedDiscrete.class);

--- a/module.config/src/main/java/dev/anvilcraft/lib/v2/config/ConfigRecord.java
+++ b/module.config/src/main/java/dev/anvilcraft/lib/v2/config/ConfigRecord.java
@@ -2,11 +2,13 @@ package dev.anvilcraft.lib.v2.config;
 
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.common.ModConfigSpec;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@ApiStatus.Internal
 public record ConfigRecord(
     String group,
     String modId,

--- a/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/AnvilLibExplosion.java
+++ b/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/AnvilLibExplosion.java
@@ -23,6 +23,7 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
 import java.util.Map;
@@ -36,10 +37,15 @@ public class AnvilLibExplosion {
     public static final AnvilLibExplosionConfig CONFIG = ConfigManager.register(MOD_ID, AnvilLibExplosionConfig::new);
     public static final Map<Block, Block> MELTING_CACHE = new ConcurrentHashMap<>();
 
+    @ApiStatus.Internal
+    public AnvilLibExplosion() {
+    }
+
     public static Identifier of(String path) {
         return Identifier.fromNamespaceAndPath(AnvilLibExplosion.MAIN_ID, path);
     }
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void onDatapackSync(OnDatapackSyncEvent event) {
         if (event.getPlayer() != null) {
@@ -48,6 +54,7 @@ public class AnvilLibExplosion {
         AnvilLibExplosion.registerMelting(event.getPlayerList().getServer());
     }
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void onServerStarted(ServerStartedEvent event) {
         AnvilLibExplosion.registerMelting(event.getServer());

--- a/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/ExplosionSession.java
+++ b/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/ExplosionSession.java
@@ -17,6 +17,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import org.apache.logging.log4j.util.TriConsumer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import java.util.stream.Collectors;
  * <p>Uses dynamic layer-by-layer generation with virtual thread pre-computation
  * to avoid memory issues with large radii and improve performance through async processing.
  */
+@ApiStatus.Internal
 class ExplosionSession {
     // Shared virtual thread executor for async layer pre-computation
     private static final Executor THREAD_EXECUTOR = Executors.newWorkStealingPool();

--- a/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/data/AnvilLibDatagen.java
+++ b/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/data/AnvilLibDatagen.java
@@ -7,8 +7,10 @@ import net.minecraft.data.PackOutput;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibExplosion.MOD_ID)
+@ApiStatus.Internal
 public class AnvilLibDatagen {
     @SubscribeEvent
     public static void gatherData(GatherDataEvent.Client event) {

--- a/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/data/provider/ModLanguageProvider.java
+++ b/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/data/provider/ModLanguageProvider.java
@@ -5,7 +5,9 @@ import dev.anvilcraft.lib.v2.explosion.AnvilLibExplosion;
 import dev.anvilcraft.lib.v2.explosion.AnvilLibExplosionConfig;
 import net.minecraft.data.PackOutput;
 import net.neoforged.neoforge.common.data.LanguageProvider;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public class ModLanguageProvider extends LanguageProvider {
     public ModLanguageProvider(PackOutput output) {
         super(output, AnvilLibExplosion.MOD_ID, "en_us");

--- a/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/mixin/SingleItemRecipeAccessor.java
+++ b/module.explosion/src/main/java/dev/anvilcraft/lib/v2/explosion/mixin/SingleItemRecipeAccessor.java
@@ -2,10 +2,12 @@ package dev.anvilcraft.lib.v2.explosion.mixin;
 
 import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.crafting.SingleItemRecipe;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(SingleItemRecipe.class)
+@ApiStatus.Internal
 public interface SingleItemRecipeAccessor {
     @Accessor
     ItemStackTemplate getResult();

--- a/module.font/src/main/java/dev/anvilcraft/lib/v2/font/AnvilLibFont.java
+++ b/module.font/src/main/java/dev/anvilcraft/lib/v2/font/AnvilLibFont.java
@@ -8,6 +8,7 @@ import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.awt.Font;
 import java.util.List;
@@ -19,6 +20,7 @@ public class AnvilLibFont {
     public static final String MOD_ID = "anvillib_font";
     public static final AnvilLibFontConfig CONFIG = new AnvilLibFontConfig();
 
+    @ApiStatus.Internal
     public AnvilLibFont(ModContainer container) {
         AnvilLibFontConfig.AnvilLibFontConfigManager.readConfig(AnvilLibFont.CONFIG);
         container.registerExtensionPoint(IConfigScreenFactory.class, FontConfigScreen::new);

--- a/module.integration/src/main/java/dev/anvilcraft/lib/v2/integration/IntegrationInstance.java
+++ b/module.integration/src/main/java/dev/anvilcraft/lib/v2/integration/IntegrationInstance.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import net.neoforged.fml.loading.moddiscovery.ModInfo;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -14,6 +15,7 @@ import java.util.List;
 @Slf4j
 @Getter
 @EqualsAndHashCode
+@ApiStatus.Internal
 public final class IntegrationInstance {
     private final String modid;
     private final ModVersionRange versionRange;

--- a/module.integration/src/main/java/dev/anvilcraft/lib/v2/integration/ModVersionRange.java
+++ b/module.integration/src/main/java/dev/anvilcraft/lib/v2/integration/ModVersionRange.java
@@ -5,11 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nullable;
 
 @Slf4j
 @Getter
+@ApiStatus.Internal
 public class ModVersionRange {
     public static final ModVersionRange ANY = new ModVersionRange(null) {
         @Override

--- a/module.main/src/main/java/dev/anvilcraft/lib/v2/AnvilLib.java
+++ b/module.main/src/main/java/dev/anvilcraft/lib/v2/AnvilLib.java
@@ -1,4 +1,7 @@
 package dev.anvilcraft.lib.v2;
 
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
 public class AnvilLib {
 }

--- a/module.moveable-entity-block/src/main/java/dev/anvilcraft/lib/v2/piston/AnvilLibMoveableEntityBlock.java
+++ b/module.moveable-entity-block/src/main/java/dev/anvilcraft/lib/v2/piston/AnvilLibMoveableEntityBlock.java
@@ -1,8 +1,10 @@
 package dev.anvilcraft.lib.v2.piston;
 
 import com.mojang.logging.LogUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.slf4j.Logger;
 
+@ApiStatus.Internal
 public class AnvilLibMoveableEntityBlock {
     public static final String MAIN_ID = "anvillib";
     public static final Logger LOGGER = LogUtils.getLogger();

--- a/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/AnvilLibMultiblock.java
+++ b/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/AnvilLibMultiblock.java
@@ -10,6 +10,7 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+import org.jetbrains.annotations.ApiStatus;
 
 @Mod(AnvilLibMultiblock.MOD_ID)
 @EventBusSubscriber(modid = AnvilLibMultiblock.MOD_ID)
@@ -21,6 +22,7 @@ public class AnvilLibMultiblock {
         AnvilLibMultiblockConfig::new
     );
 
+    @ApiStatus.Internal
     public AnvilLibMultiblock(IEventBus modEventBus, ModContainer modContainer) {
     }
 
@@ -28,6 +30,7 @@ public class AnvilLibMultiblock {
         return Identifier.fromNamespaceAndPath(MAIN_ID, path);
     }
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void onNetwork(RegisterPayloadHandlersEvent event) {
         PayloadRegistrar registrar = event.registrar("1");

--- a/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/data/AnvilLibDatagen.java
+++ b/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/data/AnvilLibDatagen.java
@@ -7,8 +7,10 @@ import net.minecraft.data.PackOutput;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibMultiblock.MOD_ID)
+@ApiStatus.Internal
 public class AnvilLibDatagen {
     @SubscribeEvent
     public static void gatherData(GatherDataEvent.Client event) {

--- a/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/data/provider/ModLanguageProvider.java
+++ b/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/data/provider/ModLanguageProvider.java
@@ -5,7 +5,9 @@ import dev.anvilcraft.lib.v2.multiblock.AnvilLibMultiblock;
 import dev.anvilcraft.lib.v2.multiblock.AnvilLibMultiblockConfig;
 import net.minecraft.data.PackOutput;
 import net.neoforged.neoforge.common.data.LanguageProvider;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public class ModLanguageProvider extends LanguageProvider {
     public ModLanguageProvider(PackOutput output) {
         super(output, AnvilLibMultiblock.MOD_ID, "en_us");

--- a/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/event/BlockEventListener.java
+++ b/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/event/BlockEventListener.java
@@ -10,8 +10,10 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 import net.neoforged.neoforge.event.server.ServerStoppedEvent;
 import net.neoforged.neoforge.event.tick.LevelTickEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibMultiblock.MOD_ID)
+@ApiStatus.Internal
 public class BlockEventListener {
     @SubscribeEvent
     public static void onPlace(BlockEvent.EntityPlaceEvent event) {

--- a/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/init/LibRegistries.java
+++ b/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/init/LibRegistries.java
@@ -7,6 +7,7 @@ import net.minecraft.resources.ResourceKey;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.registries.DataPackRegistryEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibMultiblock.MOD_ID)
 public class LibRegistries {
@@ -14,6 +15,7 @@ public class LibRegistries {
         AnvilLibMultiblock.of("definitions")
     );
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void registerDataRegistries(DataPackRegistryEvent.NewRegistry event) {
         event.dataPackRegistry(DEFINITIONS_KEY, MultiblockDefinition.CODEC.codec(), MultiblockDefinition.CODEC.codec());

--- a/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/network/MultiblockFormPacket.java
+++ b/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/network/MultiblockFormPacket.java
@@ -17,9 +17,11 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
 
 @Slf4j
 @SuppressWarnings("unused")
+@ApiStatus.Internal
 public record MultiblockFormPacket(MultiblockState state) implements IClientboundPacket {
     public static final Type<MultiblockFormPacket> TYPE = IPacket.type(AnvilLibMultiblock.of("multiblock_form"));
     public static final StreamCodec<RegistryFriendlyByteBuf, MultiblockFormPacket> STREAM_CODEC = StreamCodec.composite(

--- a/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/network/MultiblockUnformPacket.java
+++ b/module.multiblock/src/main/java/dev/anvilcraft/lib/v2/multiblock/network/MultiblockUnformPacket.java
@@ -17,9 +17,11 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
 
 @Slf4j
 @SuppressWarnings("unused")
+@ApiStatus.Internal
 public record MultiblockUnformPacket(MultiblockState state) implements IClientboundPacket {
     public static final Type<MultiblockUnformPacket> TYPE = IPacket.type(AnvilLibMultiblock.of("multiblock_unform"));
     public static final StreamCodec<RegistryFriendlyByteBuf, MultiblockUnformPacket> STREAM_CODEC = StreamCodec.composite(

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/AnvilLibRecipe.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/AnvilLibRecipe.java
@@ -7,6 +7,7 @@ import net.minecraft.resources.Identifier;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
+import org.jetbrains.annotations.ApiStatus;
 
 @Mod(AnvilLibRecipe.MOD_ID)
 public class AnvilLibRecipe {
@@ -14,6 +15,7 @@ public class AnvilLibRecipe {
     public static final String MOD_ID = "anvillib_recipe";
     public static final AnvilLibRecipeConfig CONFIG = ConfigManager.register(AnvilLibRecipe.MOD_ID, AnvilLibRecipeConfig::new);
 
+    @ApiStatus.Internal
     public AnvilLibRecipe(IEventBus modEventBus, ModContainer modContainer) {
         LibDataComponentPredicates.initialize(modEventBus);
         LibRecipeInits.init(modEventBus);

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/data/gen/AnvilLibDatagen.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/data/gen/AnvilLibDatagen.java
@@ -7,8 +7,10 @@ import net.minecraft.data.PackOutput;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibRecipe.MOD_ID)
+@ApiStatus.Internal
 public class AnvilLibDatagen {
     @SubscribeEvent
     public static void gatherData(GatherDataEvent.Client event) {

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/data/gen/provider/ModLanguageProvider.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/data/gen/provider/ModLanguageProvider.java
@@ -5,7 +5,9 @@ import dev.anvilcraft.lib.v2.recipe.AnvilLibRecipe;
 import dev.anvilcraft.lib.v2.recipe.AnvilLibRecipeConfig;
 import net.minecraft.data.PackOutput;
 import net.neoforged.neoforge.common.data.LanguageProvider;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public class ModLanguageProvider extends LanguageProvider {
     public ModLanguageProvider(PackOutput output) {
         super(output, AnvilLibRecipe.MOD_ID, "en_us");

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/event/listener/ItemEntityEventListener.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/event/listener/ItemEntityEventListener.java
@@ -9,9 +9,11 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 @EventBusSubscriber(modid = AnvilLibRecipe.MOD_ID)
+@ApiStatus.Internal
 public class ItemEntityEventListener {
     @SubscribeEvent
     public static void onItemEntityInToBlock(@NotNull ItemEntityEvent.InToBlock event) {

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/event/listener/ResourceEventListener.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/event/listener/ResourceEventListener.java
@@ -12,9 +12,11 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 @EventBusSubscriber(modid = AnvilLibRecipe.MOD_ID)
+@ApiStatus.Internal
 public class ResourceEventListener {
 //    @SubscribeEvent
 //    public static void onRecipeLoad(@NotNull RecipesUpdatedEvent event) {

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/init/LibDataComponentPredicates.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/init/LibDataComponentPredicates.java
@@ -10,6 +10,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public class LibDataComponentPredicates {
@@ -44,6 +45,7 @@ public class LibDataComponentPredicates {
         );
     }
 
+    @ApiStatus.Internal
     public static void initialize(IEventBus modEventBus) {
         DF.register(modEventBus);
     }

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/init/LibRegistries.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/init/LibRegistries.java
@@ -12,6 +12,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.registries.NewRegistryEvent;
 import net.neoforged.neoforge.registries.RegistryBuilder;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibRecipe.MOD_ID)
 public class LibRegistries {
@@ -55,6 +56,7 @@ public class LibRegistries {
         .maxId(512)
         .create();
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void registerRegistries(NewRegistryEvent event) {
         event.register(TRIGGER_REGISTRY);

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/init/recipe/LibRecipeInits.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/init/recipe/LibRecipeInits.java
@@ -1,7 +1,9 @@
 package dev.anvilcraft.lib.v2.recipe.init.recipe;
 
 import net.neoforged.bus.api.IEventBus;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public class LibRecipeInits {
     public static void init(IEventBus modEventBus) {
         LibRecipeTriggers.TRIGGER.register(modEventBus);

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/init/recipe/LibRecipeTypes.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/init/recipe/LibRecipeTypes.java
@@ -9,6 +9,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import org.jetbrains.annotations.ApiStatus;
 
 @SuppressWarnings("SameParameterValue")
 public class LibRecipeTypes {
@@ -36,6 +37,7 @@ public class LibRecipeTypes {
         );
     }
 
+    @ApiStatus.Internal
     public static void register(IEventBus bus) {
         RECIPE_TYPES.register(bus);
         RECIPE_SERIALIZERS.register(bus);

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/injection/IRecipeManagerExtension.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/injection/IRecipeManagerExtension.java
@@ -4,9 +4,11 @@ import dev.anvilcraft.lib.v2.recipe.InWorldRecipe;
 import dev.anvilcraft.lib.v2.recipe.util.InWorldRecipeManager;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.world.item.crafting.RecipeHolder;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
 
+@ApiStatus.Internal
 public interface IRecipeManagerExtension {
     default void anvillib$setInWorldRecipeManager(InWorldRecipeManager manager) {
         throw new AssertionError();

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/injection/IRecipeMapExtension.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/injection/IRecipeMapExtension.java
@@ -2,9 +2,11 @@ package dev.anvilcraft.lib.v2.recipe.injection;
 
 import dev.anvilcraft.lib.v2.recipe.InWorldRecipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
 
+@ApiStatus.Internal
 public interface IRecipeMapExtension {
     default void anvillib$addRecipes(List<RecipeHolder<InWorldRecipe>> recipes) {
         throw new AssertionError();

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/mixin/ItemEntityAccessor.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/mixin/ItemEntityAccessor.java
@@ -1,10 +1,12 @@
 package dev.anvilcraft.lib.v2.recipe.mixin;
 
 import net.minecraft.world.entity.item.ItemEntity;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(ItemEntity.class)
+@ApiStatus.Internal
 public interface ItemEntityAccessor {
     @Accessor
     void setAge(int age);

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/mixin/RecipeMapMixin.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/mixin/RecipeMapMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeMap;
 import net.minecraft.world.item.crafting.RecipeType;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -24,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 @Mixin(RecipeMap.class)
+@ApiStatus.Internal
 public class RecipeMapMixin implements IRecipeMapExtension {
     @Mutable
     @Final

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/providers/RegistrumDataProvider.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/providers/RegistrumDataProvider.java
@@ -26,6 +26,7 @@ import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.resources.ResourceKey;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -37,6 +38,7 @@ import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
 @Log4j2
+@ApiStatus.Internal
 public class RegistrumDataProvider implements DataProvider {
 
     @SuppressWarnings("null")

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/DebugMarkers.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/DebugMarkers.java
@@ -15,8 +15,10 @@ package dev.anvilcraft.lib.v2.registrum.util;
 
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
+import org.jetbrains.annotations.ApiStatus;
 
 @SuppressWarnings("null")
+@ApiStatus.Internal
 public class DebugMarkers {
 
     private static final String PREFIX = "REGISTRATE.";

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/OneTimeEventReceiver.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/OneTimeEventReceiver.java
@@ -27,6 +27,7 @@ import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import java.util.function.Consumer;
 @SuppressWarnings("unused")
 @RequiredArgsConstructor
 @Log4j2
+@ApiStatus.Internal
 public class OneTimeEventReceiver<T extends Event> implements Consumer<@NonnullType T> {
 
 

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/RegistrumDistExecutor.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/RegistrumDistExecutor.java
@@ -15,9 +15,11 @@ package dev.anvilcraft.lib.v2.registrum.util;
 
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.loading.FMLLoader;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.function.Supplier;
 
+@ApiStatus.Internal
 public class RegistrumDistExecutor {
     public static void unsafeRunWhenOn(Dist dist, Supplier<Runnable> toRun) {
         if (dist == FMLLoader.getCurrent().getDist()) {

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/ALRPipelines.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/ALRPipelines.java
@@ -11,6 +11,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RegisterRenderPipelinesEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(Dist.CLIENT)
 public class ALRPipelines {
@@ -76,6 +77,7 @@ public class ALRPipelines {
         .build();
 
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void on(RegisterRenderPipelinesEvent event) {
         event.registerPipeline(BLUR);

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/ALRPostEffects.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/ALRPostEffects.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix4fc;
 
 @Slf4j
@@ -45,6 +46,7 @@ public class ALRPostEffects {
         }
     }
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void on(MainTargetResizeEvent event) {
         BloomPostEffect bloomPostEffect = ALRPostEffects.getBloomPostEffect();

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/AnvilLibRendering.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/AnvilLibRendering.java
@@ -17,10 +17,12 @@ import net.neoforged.neoforge.client.event.AddClientReloadListenersEvent;
 import net.neoforged.neoforge.client.event.RegisterPictureInPictureRenderersEvent;
 import net.neoforged.neoforge.client.event.RenderFrameEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @Slf4j
 @Mod(value = AnvilLibRendering.MODID, dist = Dist.CLIENT)
 @EventBusSubscriber(Dist.CLIENT)
+@ApiStatus.Internal
 public class AnvilLibRendering {
     public static final boolean DEBUG = System.getProperty("anvillib.rendering.debugMode") != null;
     public static final String MODID = "anvillib_rendering";

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/cachedber/pipeline/CachedBlockEntityRenderingPipeline.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/cachedber/pipeline/CachedBlockEntityRenderingPipeline.java
@@ -15,6 +15,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RenderFrameEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 import org.lwjgl.opengl.GL;
 import org.lwjgl.opengl.GL46;
@@ -163,6 +164,7 @@ public class CachedBlockEntityRenderingPipeline {
         getRenderRegion(ChunkPos.containing(pos)).forcedUpdate();
     }
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void on(RenderLevelStageEvent.AfterSky event) {
         Vec3 pos = event.getLevelRenderState().cameraRenderState.pos;
@@ -174,6 +176,7 @@ public class CachedBlockEntityRenderingPipeline {
         cameraMoved = true;
     }
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void on(RenderFrameEvent.Pre event) {
         if (instance != null) {

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/cachedber/pipeline/RebuildTask.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/cachedber/pipeline/RebuildTask.java
@@ -15,6 +15,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 
 import java.util.ArrayList;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public class RebuildTask implements Runnable {
     private final CachedRenderingChunk owner;
     private boolean cancelled = false;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/ALRCommandEncoderBackendExtension.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/ALRCommandEncoderBackendExtension.java
@@ -3,6 +3,7 @@ package dev.anvilcraft.lib.v2.rendering.extension.blaze3d;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.pipeline.ALRComputePass;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public interface ALRCommandEncoderBackendExtension {
     void alrDispatchWorkgroups(
         int groupCountX,

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/ALRGpuDeviceBackendExtension.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/ALRGpuDeviceBackendExtension.java
@@ -4,6 +4,7 @@ import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.pipeline.ALRCom
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstance;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstanceKey;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public interface ALRGpuDeviceBackendExtension {
     ALRComputeProgramInstance alrCompileComputeShader(ALRComputeProgramInstanceKey instanceKey);
 

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/compute/pipeline/gl/GlComputePassBackend.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/compute/pipeline/gl/GlComputePassBackend.java
@@ -25,6 +25,7 @@ import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL33;
 import org.lwjgl.opengl.GL46;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public class GlComputePassBackend implements ALRComputePassBackend {
     private final ALRGpuDeviceBackendExtension backendExtension;
     private final ALRCommandEncoderBackendExtension commandEncoderExtension;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/BlockStatePipRenderer.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/BlockStatePipRenderer.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public class BlockStatePipRenderer extends PictureInPictureRenderer<BlockStatePipRenderingState> {
     public BlockStatePipRenderer(MultiBufferSource.BufferSource bufferSource) {
         super(bufferSource);

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/StructurePipRenderer.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/StructurePipRenderer.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.OptionalInt;
 
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public class StructurePipRenderer extends PictureInPictureRenderer<StructurePipRenderingState> {
 
     private final BlockAndTintGetter emptyTintedLevel = new SimpleTintedEmptyLevelAccess();

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/BlockStatePipRenderingState.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/BlockStatePipRenderingState.java
@@ -12,6 +12,7 @@ import org.jspecify.annotations.Nullable;
 
 import static dev.anvilcraft.lib.v2.rendering.ALRSharedMath.SQRT_2;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public record BlockStatePipRenderingState(
     BlockState blockState,
     @Nullable BlockAndTintGetter level,

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/DynamicTextureBlitRenderState.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/DynamicTextureBlitRenderState.java
@@ -10,6 +10,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public record DynamicTextureBlitRenderState(
     RenderPipeline pipeline,
     Supplier<TextureSetup> textureSetupSupplier,

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/ALRIntegrationCompatMixinPlugin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/ALRIntegrationCompatMixinPlugin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import java.util.List;
 import java.util.Set;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public class ALRIntegrationCompatMixinPlugin implements IMixinConfigPlugin {
 
     private ImmutableMap<String, Boolean> mixinConditions;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/CachedBlockEntityRenderingPipelineMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/CachedBlockEntityRenderingPipelineMixin.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CachedBlockEntityRenderingPipeline.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public abstract class CachedBlockEntityRenderingPipelineMixin {
 
     @Shadow

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/RebuildTaskMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/RebuildTaskMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RebuildTask.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class RebuildTaskMixin {
     @Inject(
         method = "run",

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GameRendererMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GameRendererMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class GameRendererMixin {
 
     @Inject(

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GuiGraphicsExtractorMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GuiGraphicsExtractorMixin.java
@@ -23,6 +23,7 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @SuppressWarnings("AddedMixinMembersNamePattern")
 @Mixin(GuiGraphicsExtractor.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class GuiGraphicsExtractorMixin implements GuiGraphicsExtractorExtension {
 
     @Shadow

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GuiRendererMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GuiRendererMixin.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 @Mixin(GuiRenderer.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class GuiRendererMixin {
     @Unique
     private GuiElementRenderState anvillib$renderState = null;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/ItemStackRenderStateMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/ItemStackRenderStateMixin.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(ItemStackRenderState.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class ItemStackRenderStateMixin implements ItemStackRenderStateInternals.Extension {
     @Unique
     private float anvillib_rendering$alpha = 1f;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/MinecraftMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/MinecraftMixin.java
@@ -14,6 +14,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Minecraft.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class MinecraftMixin {
 
     @Shadow

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/RenderTypeMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/RenderTypeMixin.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(RenderType.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class RenderTypeMixin implements ALRRenderTypeExtension {
 
     @Unique

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/CommandEncoderMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/CommandEncoderMixin.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(CommandEncoder.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class CommandEncoderMixin implements ALRCommandEncoderExtension {
     @Shadow
     @Final

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/GpuDeviceMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/GpuDeviceMixin.java
@@ -14,6 +14,7 @@ import org.spongepowered.asm.mixin.Unique;
 
 @SuppressWarnings("AddedMixinMembersNamePattern")
 @Mixin(GpuDevice.class)
+@org.jetbrains.annotations.ApiStatus.Internal
 public class GpuDeviceMixin implements ALRGpuDeviceExtension {
     @Shadow
     @Final

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/DirectStateAccessMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/DirectStateAccessMixin.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public class DirectStateAccessMixin {
 
     @Mixin(targets = "com.mojang.blaze3d.opengl.DirectStateAccess$Emulated")

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlCommandEncoderMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlCommandEncoderMixin.java
@@ -17,6 +17,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(targets = "com.mojang.blaze3d.opengl.GlCommandEncoder")
+@org.jetbrains.annotations.ApiStatus.Internal
 public class GlCommandEncoderMixin implements ALRCommandEncoderBackendExtension {
     @Shadow
     @Final

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlDebugLabelMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlDebugLabelMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public class GlDebugLabelMixin {
     @Mixin(GlDebugLabel.class)
     public static class Self implements ALRDebugLabelExtension {

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlDeviceMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlDeviceMixin.java
@@ -14,6 +14,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(targets = "com.mojang.blaze3d.opengl.GlDevice")
+@org.jetbrains.annotations.ApiStatus.Internal
 public abstract class GlDeviceMixin implements ALRGpuDeviceBackendExtension {
 
     @Shadow

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/sdf/SdfGraphics.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/sdf/SdfGraphics.java
@@ -24,6 +24,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ConfigureMainRenderTargetEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix3x2f;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -371,6 +372,7 @@ public final class SdfGraphics {
 
     private static  int             index;
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void init(ConfigureMainRenderTargetEvent event) {
         GpuDevice device    = RenderSystem.getDevice();

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/AnvilLibRpc.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/AnvilLibRpc.java
@@ -10,8 +10,10 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.server.ServerStoppedEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.network.event.RegisterConfigurationTasksEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @Mod(AnvilLibRpc.MOD_ID)
+@ApiStatus.Internal
 public class AnvilLibRpc {
     public static final String MAIN_ID = "anvillib";
     public static final String MOD_ID = "anvillib_rpc";

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/AnvilLibRpcNetwork.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/AnvilLibRpcNetwork.java
@@ -5,11 +5,13 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * 注册 RPC 网络包。
  */
 @EventBusSubscriber(modid = AnvilLibRpc.MOD_ID)
+@ApiStatus.Internal
 public class AnvilLibRpcNetwork {
     public static final String NETWORK_VERSION = "1";
 

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/IRpcPayload.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/IRpcPayload.java
@@ -2,9 +2,11 @@ package dev.anvilcraft.lib.v2.rpc;
 
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.reflect.Method;
 
+@ApiStatus.Internal
 public interface IRpcPayload {
     static byte[] encodeParams(RpcRegistry registry, Method method, Object[] args, RegistryFriendlyByteBuf buf) {
         buf.writeVarInt(registry.index(method));

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RpcPayload.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RpcPayload.java
@@ -13,6 +13,7 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -31,6 +32,7 @@ import java.lang.reflect.Method;
  *
  * @see RPC#call
  */
+@ApiStatus.Internal
 public class RpcPayload implements IRpcPayload, IInsensitiveBiPacket {
     public static final Type<RpcPayload> TYPE = IPacket.type(AnvilLibRpc.mod("rpc"));
     public static final StreamCodec<ByteBuf, RpcPayload> STREAM_CODEC = StreamCodec.composite(

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RpcRequestPayload.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RpcRequestPayload.java
@@ -13,6 +13,7 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -23,6 +24,7 @@ import java.lang.reflect.Method;
  *
  * @see RPC#invoke
  */
+@ApiStatus.Internal
 public class RpcRequestPayload implements IRpcPayload, IInsensitiveBiPacket {
     public static final Type<RpcRequestPayload> TYPE = IPacket.type(AnvilLibRpc.mod("rpc_request"));
     public static final StreamCodec<ByteBuf, RpcRequestPayload> STREAM_CODEC = StreamCodec.composite(

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RpcResponsePayload.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RpcResponsePayload.java
@@ -13,6 +13,7 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletionException;
@@ -25,6 +26,7 @@ import java.util.concurrent.CompletionException;
  *
  * @see RPC#invoke
  */
+@ApiStatus.Internal
 public class RpcResponsePayload implements IInsensitiveBiPacket {
     public static final Type<RpcResponsePayload> TYPE = IPacket.type(AnvilLibRpc.mod("rpc_response"));
     public static final StreamCodec<ByteBuf, RpcResponsePayload> STREAM_CODEC = StreamCodec.composite(

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/client/AnvilLibRpcClient.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/client/AnvilLibRpcClient.java
@@ -11,6 +11,7 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * 客户端侧入口，持有仅采纳服务端下发映射的客户端索引表。
@@ -19,6 +20,7 @@ import net.neoforged.neoforge.common.NeoForge;
  * 从而保证客户端断开后开启局域网时，集成服务端仍下发其本地扫描得到的正确映射。</p>
  */
 @Mod(value = AnvilLibRpc.MOD_ID, dist = Dist.CLIENT)
+@ApiStatus.Internal
 public class AnvilLibRpcClient {
     /**
      * 客户端索引表：仅通过 {@link RpcRegistry#adopt} 采纳服务端下发的映射。

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/config/RpcConfigurationFinishPayload.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/config/RpcConfigurationFinishPayload.java
@@ -7,10 +7,12 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * 客户端在采纳服务端 RPC 索引映射后回复的结束包，用于标记 {@link RpcConfigurationTask} 完成。
  */
+@ApiStatus.Internal
 public class RpcConfigurationFinishPayload implements IServerboundPacket {
     public static final RpcConfigurationFinishPayload INSTANCE = new RpcConfigurationFinishPayload();
     public static final Type<RpcConfigurationFinishPayload> TYPE = IPacket.type(AnvilLibRpc.mod("rpc_config_finish"));

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/config/RpcConfigurationPayload.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/config/RpcConfigurationPayload.java
@@ -9,6 +9,7 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +21,7 @@ import java.util.Map;
  * {@code 索引 -> 规范键} 映射，保证双向 RPC 的索引一致；随后回复
  * {@link RpcConfigurationFinishPayload} 以结束该配置任务。</p>
  */
+@ApiStatus.Internal
 public record RpcConfigurationPayload(Map<Integer, String> indexMap) implements IClientboundPacket {
     public static final Type<RpcConfigurationPayload> TYPE = IPacket.type(AnvilLibRpc.mod("rpc_config"));
     public static final StreamCodec<ByteBuf, RpcConfigurationPayload> STREAM_CODEC = StreamCodec.composite(

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/config/RpcConfigurationTask.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/config/RpcConfigurationTask.java
@@ -3,12 +3,14 @@ package dev.anvilcraft.lib.v2.rpc.config;
 import dev.anvilcraft.lib.v2.rpc.AnvilLibRpc;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.neoforged.neoforge.network.configuration.ICustomConfigurationTask;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.function.Consumer;
 
 /**
  * 服务端配置任务：在 Configuration 阶段向客户端下发权威的 RPC 索引映射。
  */
+@ApiStatus.Internal
 public record RpcConfigurationTask() implements ICustomConfigurationTask {
     public static final Type TYPE = new Type(AnvilLibRpc.mod("rpc_config"));
 

--- a/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/AnvilLibSpaceSelect.java
+++ b/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/AnvilLibSpaceSelect.java
@@ -2,9 +2,14 @@ package dev.anvilcraft.lib.v2.space_select;
 
 import net.minecraft.resources.Identifier;
 import net.neoforged.fml.common.Mod;
+import org.jetbrains.annotations.ApiStatus;
 
 @Mod(AnvilLibSpaceSelect.MOD_ID)
 public class AnvilLibSpaceSelect {
+    @ApiStatus.Internal
+    public AnvilLibSpaceSelect() {
+    }
+
     public static final String MOD_ID = "anvillib_space_select";
 
     public static Identifier of(String path) {

--- a/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/client/AnvilLibSpaceSelectClient.java
+++ b/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/client/AnvilLibSpaceSelectClient.java
@@ -3,8 +3,13 @@ package dev.anvilcraft.lib.v2.space_select.client;
 import dev.anvilcraft.lib.v2.space_select.AnvilLibSpaceSelect;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.common.Mod;
+import org.jetbrains.annotations.ApiStatus;
 
 @Mod(value = AnvilLibSpaceSelect.MOD_ID, dist = Dist.CLIENT)
 public class AnvilLibSpaceSelectClient {
+    @ApiStatus.Internal
+    public AnvilLibSpaceSelectClient() {
+    }
+
     public static final ClientDistrictManager MANAGER = new ClientDistrictManager();
 }

--- a/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/client/DistrictRenderer.java
+++ b/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/client/DistrictRenderer.java
@@ -18,11 +18,13 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @EventBusSubscriber(modid = AnvilLibSpaceSelect.MOD_ID, value = Dist.CLIENT)
+@ApiStatus.Internal
 public class DistrictRenderer {
     @SubscribeEvent
     public static void addLevelRenderMainPass(RenderLevelStageEvent.AfterTranslucentParticles event) {

--- a/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/client/SpaceSelectScrollHandler.java
+++ b/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/client/SpaceSelectScrollHandler.java
@@ -11,8 +11,10 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.InputEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibSpaceSelect.MOD_ID, value = Dist.CLIENT)
+@ApiStatus.Internal
 public final class SpaceSelectScrollHandler {
 
     private SpaceSelectScrollHandler() {

--- a/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/event/handler/PlayerCreateDistrictEventHandler.java
+++ b/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/event/handler/PlayerCreateDistrictEventHandler.java
@@ -5,8 +5,10 @@ import dev.anvilcraft.lib.v2.space_select.SpaceSelectItem;
 import dev.anvilcraft.lib.v2.space_select.event.PlayerCreateDistrictEvent;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibSpaceSelect.MOD_ID)
+@ApiStatus.Internal
 public class PlayerCreateDistrictEventHandler {
     @SubscribeEvent
     public static void onPlayerCreateDistrict(PlayerCreateDistrictEvent event) {

--- a/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/network/AnvilLibSpaceSelectNetwork.java
+++ b/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/network/AnvilLibSpaceSelectNetwork.java
@@ -6,8 +6,10 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibSpaceSelect.MOD_ID)
+@ApiStatus.Internal
 public class AnvilLibSpaceSelectNetwork {
     public static final String NETWORK_VERSION = "1";
 

--- a/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/network/payload/SpaceSelectPayload.java
+++ b/module.space-select/src/main/java/dev/anvilcraft/lib/v2/space_select/network/payload/SpaceSelectPayload.java
@@ -10,7 +10,9 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public record SpaceSelectPayload(
     boolean offhand,
     BlockPos start,

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/LazySyncBytecodeInjector.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/LazySyncBytecodeInjector.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
  * 每 tick 扫描差分，故此处无需注入任何字段写入拦截。</p>
  */
 @Slf4j
+@org.jetbrains.annotations.ApiStatus.Internal
 public class LazySyncBytecodeInjector {
     private static final String LAZY_SYNC_DESC = "Ldev/anvilcraft/lib/v2/sync/annotation/LazySync;";
     private static final String ANVIL_LIB_SYNC_INTERNAL = "dev/anvilcraft/lib/v2/sync/AnvilLibSync";

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/LazySyncTargetIndex.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/LazySyncTargetIndex.java
@@ -19,6 +19,7 @@ import java.util.Set;
  * 通过反射读取，故此处仅需记录类的集合。</p>
  */
 @Slf4j
+@org.jetbrains.annotations.ApiStatus.Internal
 public class LazySyncTargetIndex {
     public static final String LAZY_SYNC_DESCRIPTOR = "Ldev/anvilcraft/lib/v2/sync/annotation/LazySync;";
     private static final Set<String> TARGETS = new HashSet<>();

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncBytecodeInjector.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncBytecodeInjector.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
  * Static fields    → proxy.setParent(Owner.class) in <clinit> (created if absent)
  */
 @Slf4j
+@org.jetbrains.annotations.ApiStatus.Internal
 public class SyncBytecodeInjector {
     private static final String SYNC_PROXY_DESC = "Ldev/anvilcraft/lib/v2/sync/management/SyncProxy;";
     private static final String SYNC_PROXY_INTERNAL = "dev/anvilcraft/lib/v2/sync/management/SyncProxy";

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncClassProcessor.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncClassProcessor.java
@@ -7,6 +7,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 
 @Slf4j
+@org.jetbrains.annotations.ApiStatus.Internal
 public class SyncClassProcessor implements ClassProcessor {
     @Override
     public ProcessorName name() {

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncTargetIndex.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncTargetIndex.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
+@org.jetbrains.annotations.ApiStatus.Internal
 public class SyncTargetIndex {
     public static final String SYNC_DESCRIPTOR = "Ldev/anvilcraft/lib/v2/sync/annotation/Sync;";
     private static final Map<String, String> TARGETS = new HashMap<>();

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/AnvilLibSync.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/AnvilLibSync.java
@@ -21,12 +21,14 @@ import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.network.configuration.ICustomConfigurationTask;
 import net.neoforged.neoforge.network.event.RegisterConfigurationTasksEvent;
 import net.neoforged.neoforge.registries.RegisterEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Objects;
 import java.util.function.Consumer;
 
 @Slf4j
 @Mod(AnvilLibSync.MOD_ID)
+@ApiStatus.Internal
 public class AnvilLibSync {
     public static final String MOD_ID = "anvillib_sync";
     public static final SyncManager SYNC_MANAGER = new SyncManager();

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/client/AnvilLibSyncClient.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/client/AnvilLibSyncClient.java
@@ -10,8 +10,10 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
 
 @Mod(value = AnvilLibSync.MOD_ID, dist = Dist.CLIENT)
+@ApiStatus.Internal
 public class AnvilLibSyncClient {
     public static final SyncConfigManager SYNC_CONFIG_MANAGER = new SyncConfigManager();
 

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/init/AnvilLibSyncRegistries.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/init/AnvilLibSyncRegistries.java
@@ -8,6 +8,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.registries.NewRegistryEvent;
 import net.neoforged.neoforge.registries.RegistryBuilder;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibSync.MOD_ID)
 public class AnvilLibSyncRegistries {
@@ -18,6 +19,7 @@ public class AnvilLibSyncRegistries {
         .maxId(512)
         .create();
 
+    @ApiStatus.Internal
     @SubscribeEvent
     public static void registerRegistries(NewRegistryEvent event) {
         event.register(SYNC_ENTRY_REGISTRY);

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/management/LazySyncManager.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/management/LazySyncManager.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * {@code ItemStack}）的原地修改，且复用网络线格式，代价是每 tick 对每个被跟踪字段编码一次。</p>
  */
 @Slf4j
+@ApiStatus.Internal
 public class LazySyncManager {
     /**
      * 单侧状态：被跟踪的实例 / 静态目标及其字段快照。

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/management/SyncConfigManager.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/management/SyncConfigManager.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 
 @Slf4j
+@ApiStatus.Internal
 public class SyncConfigManager {
     public static final String SYNC_DESCRIPTOR = "Ldev/anvilcraft/lib/v2/sync/annotation/Sync;";
     public static final String LAZY_SYNC_DESCRIPTOR = "Ldev/anvilcraft/lib/v2/sync/annotation/LazySync;";

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/management/SyncManager.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/management/SyncManager.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.Set;
 
 @Slf4j
+@ApiStatus.Internal
 public class SyncManager {
     private final Map<Class<?>, SyncRegisterEntry<?, ?>> syncRegisterEntryMap = new HashMap<>();
 

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/AnvilLibSyncNetwork.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/AnvilLibSyncNetwork.java
@@ -6,8 +6,10 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibSync.MOD_ID)
+@ApiStatus.Internal
 public class AnvilLibSyncNetwork {
     public static final String NETWORK_VERSION = "1";
 

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/LazySyncPayload.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/LazySyncPayload.java
@@ -40,6 +40,7 @@ import java.util.List;
  * </pre>
  */
 @Slf4j
+@org.jetbrains.annotations.ApiStatus.Internal
 public record LazySyncPayload(
     byte[] array
 ) implements IInsensitiveBiPacket {

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncConfigurationFinishPayload.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncConfigurationFinishPayload.java
@@ -7,7 +7,9 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public class SyncConfigurationFinishPayload implements IServerboundPacket {
     public static final SyncConfigurationFinishPayload INSTANCE = new SyncConfigurationFinishPayload();
     public static final Type<SyncConfigurationFinishPayload> TYPE = IPacket.type(AnvilLibSync.of("sync_config_finish"));

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncConfigurationPayload.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncConfigurationPayload.java
@@ -13,6 +13,7 @@ import net.neoforged.neoforge.network.handling.IPayloadContext;
 import java.util.HashMap;
 import java.util.Map;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public record SyncConfigurationPayload(
     Map<Integer, String> syncMap
 ) implements IClientboundPacket {

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncPayload.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncPayload.java
@@ -22,6 +22,7 @@ import net.neoforged.neoforge.network.handling.IPayloadContext;
 import java.lang.reflect.Field;
 import java.util.Objects;
 
+@org.jetbrains.annotations.ApiStatus.Internal
 public record SyncPayload(
     byte[] array
 ) implements IInsensitiveBiPacket {

--- a/module.util/src/main/java/dev/anvilcraft/lib/v2/util/AnvilLibUtil.java
+++ b/module.util/src/main/java/dev/anvilcraft/lib/v2/util/AnvilLibUtil.java
@@ -2,9 +2,14 @@ package dev.anvilcraft.lib.v2.util;
 
 import net.minecraft.resources.Identifier;
 import net.neoforged.fml.common.Mod;
+import org.jetbrains.annotations.ApiStatus;
 
 @Mod(AnvilLibUtil.MOD_ID)
 public class AnvilLibUtil {
+    @ApiStatus.Internal
+    public AnvilLibUtil() {
+    }
+
     public static final String MAIN_ID = "anvillib";
     public static final String MOD_ID = "anvillib_util";
 

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/AnvilLibWheel.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/AnvilLibWheel.java
@@ -7,8 +7,10 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ConfigureMainRenderTargetEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 @EventBusSubscriber(modid = AnvilLibWheel.MOD_ID, value = Dist.CLIENT)
+@ApiStatus.Internal
 public class AnvilLibWheel {
     public static final String MOD_ID = "anvillib_wheel";
     public static final String MAIN_ID = "anvillib";

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/render/state/AnnularSectorRenderState.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/render/state/AnnularSectorRenderState.java
@@ -7,10 +7,12 @@ import dev.anvilcraft.lib.v2.rendering.state.LibQuadGuiElementRenderState;
 import dev.anvilcraft.lib.v2.wheel.client.init.LibRenders;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import org.joml.Matrix3x2f;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Map;
 import javax.annotation.Nullable;
 
+@ApiStatus.Internal
 public record AnnularSectorRenderState(
     Matrix3x2f pose,
     float x0,

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/render/state/RingRenderState.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/render/state/RingRenderState.java
@@ -9,10 +9,12 @@ import dev.anvilcraft.lib.v2.wheel.client.init.LibRenders;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.render.TextureSetup;
 import org.joml.Matrix3x2f;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Map;
 import javax.annotation.Nullable;
 
+@ApiStatus.Internal
 public record RingRenderState(
     Matrix3x2f pose,
     float x0,

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/render/state/SelectionRenderState.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/render/state/SelectionRenderState.java
@@ -7,10 +7,12 @@ import dev.anvilcraft.lib.v2.rendering.state.LibQuadGuiElementRenderState;
 import dev.anvilcraft.lib.v2.wheel.client.init.LibRenders;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import org.joml.Matrix3x2f;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Map;
 import javax.annotation.Nullable;
 
+@ApiStatus.Internal
 public record SelectionRenderState(
     Matrix3x2f pose,
     float x0,

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/init/LibDynamicUniforms.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/init/LibDynamicUniforms.java
@@ -11,10 +11,12 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RenderGuiEvent;
 import org.joml.Vector2fc;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.nio.ByteBuffer;
 
 @EventBusSubscriber(modid = AnvilLibWheel.MOD_ID, value = Dist.CLIENT)
+@ApiStatus.Internal
 public class LibDynamicUniforms {
     private final DynamicUniformStorage<RingUniform> ringUbo = new DynamicUniformStorage<>(
         "RingUniform UBO",

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/init/LibRenders.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/init/LibRenders.java
@@ -7,7 +7,9 @@ import com.mojang.blaze3d.shaders.UniformType;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import dev.anvilcraft.lib.v2.wheel.AnvilLibWheel;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public class LibRenders {
     public static final RenderPipeline.Snippet SNIPPET_COMMON = RenderPipeline.builder()
         .withUniform("DynamicTransforms", UniformType.UNIFORM_BUFFER)

--- a/renderdoc-loader/build.gradle
+++ b/renderdoc-loader/build.gradle
@@ -22,6 +22,10 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    compileOnly 'org.jetbrains:annotations:26.0.2-1'
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)

--- a/renderdoc-loader/src/main/java/dev/anvilcraft/lib/renderdoc/loader/RenderDocAgent.java
+++ b/renderdoc-loader/src/main/java/dev/anvilcraft/lib/renderdoc/loader/RenderDocAgent.java
@@ -1,5 +1,7 @@
 package dev.anvilcraft.lib.renderdoc.loader;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.lang.instrument.Instrumentation;
 
 /**
@@ -9,6 +11,7 @@ import java.lang.instrument.Instrumentation;
  * for graphics debugging purposes.
  * </p>
  */
+@ApiStatus.Internal
 public class RenderDocAgent {
 
     /**


### PR DESCRIPTION
- 在多个模块的接口和类上添加 @org.jetbrains.annotations.ApiStatus.Internal 注解
- 为渲染模块的扩展接口添加内部注解
- 给配置、爆炸、多方块结构等模块的内部类添加注解
- 为网络、RPC、同步等功能模块的实现类添加内部注解
- 在构建脚本中添加 jetbrains annotations 依赖
- 为渲染相关的混合类和后端实现添加内部注解
- 给空间选择和轮子模块的内部组件添加注解