### PR TITLE
refactor(common): 优化代码导入

### DIFF
--- a/module.font/src/main/java/dev/anvilcraft/lib/v2/font/sdf/SdfTextLayout.java
+++ b/module.font/src/main/java/dev/anvilcraft/lib/v2/font/sdf/SdfTextLayout.java
@@ -7,6 +7,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,7 +87,7 @@ public final class SdfTextLayout {
     @Nullable
     private static SdfTextLayout computeLayout(SdfGlyphAtlas atlas, String text, float scale, int scaleInt) {
         int penX = 0, maxHeight = 0;
-        java.util.Map<Integer, List<GlyphQuad>> buckets = new java.util.LinkedHashMap<>();
+        Map<Integer, List<GlyphQuad>> buckets = new LinkedHashMap<>();
         boolean allAvailable = true;
 
         Set<SdfGlyphPage> glyphPages = new HashSet<>();

--- a/module.font/src/main/java/dev/anvilcraft/lib/v2/font/sdf/SdfTextRenderer.java
+++ b/module.font/src/main/java/dev/anvilcraft/lib/v2/font/sdf/SdfTextRenderer.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.Beta;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuSampler;
+import dev.anvilcraft.lib.v2.font.ALFont;
 import dev.anvilcraft.lib.v2.font.sdf.state.SdfTextRenderState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -231,7 +232,7 @@ public final class SdfTextRenderer {
     }
 
     private static List<String> wrapLines(SdfGlyphAtlas atlas, String text, int maxWidth, float scale) {
-        return dev.anvilcraft.lib.v2.font.ALFont.wrapLines(atlas, text, maxWidth, scale);
+        return ALFont.wrapLines(atlas, text, maxWidth, scale);
     }
 
     private static String flattenToString(FormattedCharSequence text) {

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/providers/generators/RegistrumRecipeProvider.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/providers/generators/RegistrumRecipeProvider.java
@@ -484,7 +484,7 @@ public class RegistrumRecipeProvider extends RecipeProvider implements RecipeOut
     }
 
     @Override
-    public void oneToOneConversionRecipe(ItemLike product, ItemLike resource, @org.jspecify.annotations.Nullable String group) {
+    public void oneToOneConversionRecipe(ItemLike product, ItemLike resource, @Nullable String group) {
         super.oneToOneConversionRecipe(product, resource, group);
     }
 
@@ -492,7 +492,7 @@ public class RegistrumRecipeProvider extends RecipeProvider implements RecipeOut
     public void oneToOneConversionRecipe(
         ItemLike product,
         ItemLike resource,
-        @org.jspecify.annotations.Nullable String group,
+        @Nullable String group,
         int productCount
     ) {
         super.oneToOneConversionRecipe(product, resource, group, productCount);

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/cachedber/pipeline/RebuildTask.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/cachedber/pipeline/RebuildTask.java
@@ -12,10 +12,11 @@ import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class RebuildTask implements Runnable {
     private final CachedRenderingChunk owner;
     private boolean cancelled = false;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/ALRCommandEncoderBackendExtension.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/ALRCommandEncoderBackendExtension.java
@@ -2,8 +2,9 @@ package dev.anvilcraft.lib.v2.rendering.extension.blaze3d;
 
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.pipeline.ALRComputePass;
+import org.jetbrains.annotations.ApiStatus;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public interface ALRCommandEncoderBackendExtension {
     void alrDispatchWorkgroups(
         int groupCountX,

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/ALRGpuDeviceBackendExtension.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/ALRGpuDeviceBackendExtension.java
@@ -3,8 +3,9 @@ package dev.anvilcraft.lib.v2.rendering.extension.blaze3d;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.pipeline.ALRComputePass;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstance;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstanceKey;
+import org.jetbrains.annotations.ApiStatus;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public interface ALRGpuDeviceBackendExtension {
     ALRComputeProgramInstance alrCompileComputeShader(ALRComputeProgramInstanceKey instanceKey);
 

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/compute/pipeline/gl/GlComputePassBackend.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/extension/blaze3d/compute/pipeline/gl/GlComputePassBackend.java
@@ -18,6 +18,7 @@ import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRCompu
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeShaderManager;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.jetbrains.annotations.ApiStatus;
 import org.lwjgl.opengl.ARBShaderAtomicCounters;
 import org.lwjgl.opengl.ARBShaderImageLoadStore;
 import org.lwjgl.opengl.ARBShaderStorageBufferObject;
@@ -25,7 +26,7 @@ import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL33;
 import org.lwjgl.opengl.GL46;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class GlComputePassBackend implements ALRComputePassBackend {
     private final ALRGpuDeviceBackendExtension backendExtension;
     private final ALRCommandEncoderBackendExtension commandEncoderExtension;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/BlockStatePipRenderer.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/BlockStatePipRenderer.java
@@ -23,9 +23,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.ApiStatus;
 
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class BlockStatePipRenderer extends PictureInPictureRenderer<BlockStatePipRenderingState> {
     public BlockStatePipRenderer(MultiBufferSource.BufferSource bufferSource) {
         super(bufferSource);

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/StructurePipRenderer.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/renderer/StructurePipRenderer.java
@@ -40,6 +40,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
 import org.joml.Vector4f;
@@ -49,7 +50,7 @@ import java.util.Map;
 import java.util.OptionalInt;
 
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class StructurePipRenderer extends PictureInPictureRenderer<StructurePipRenderingState> {
 
     private final BlockAndTintGetter emptyTintedLevel = new SimpleTintedEmptyLevelAccess();

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/BlockStatePipRenderingState.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/BlockStatePipRenderingState.java
@@ -7,12 +7,13 @@ import net.minecraft.client.renderer.state.gui.pip.PictureInPictureRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix3x2f;
 import org.jspecify.annotations.Nullable;
 
 import static dev.anvilcraft.lib.v2.rendering.ALRSharedMath.SQRT_2;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public record BlockStatePipRenderingState(
     BlockState blockState,
     @Nullable BlockAndTintGetter level,

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/DynamicTextureBlitRenderState.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/gui/state/DynamicTextureBlitRenderState.java
@@ -5,12 +5,13 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.render.TextureSetup;
 import net.minecraft.client.renderer.state.gui.GuiElementRenderState;
+import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix3x2f;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public record DynamicTextureBlitRenderState(
     RenderPipeline pipeline,
     Supplier<TextureSetup> textureSetupSupplier,

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/ALRIntegrationCompatMixinPlugin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/ALRIntegrationCompatMixinPlugin.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import dev.anvilcraft.lib.v2.rendering.integration.IrisSupport;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.LoadingModList;
+import org.jetbrains.annotations.ApiStatus;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import java.util.List;
 import java.util.Set;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class ALRIntegrationCompatMixinPlugin implements IMixinConfigPlugin {
 
     private ImmutableMap<String, Boolean> mixinConditions;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/CachedBlockEntityRenderingPipelineMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/CachedBlockEntityRenderingPipelineMixin.java
@@ -2,6 +2,7 @@ package dev.anvilcraft.lib.v2.rendering.integration.mixins;
 
 import dev.anvilcraft.lib.v2.rendering.cachedber.pipeline.CachedBlockEntityRenderingPipeline;
 import dev.anvilcraft.lib.v2.rendering.integration.IrisSupport;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -10,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CachedBlockEntityRenderingPipeline.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public abstract class CachedBlockEntityRenderingPipelineMixin {
 
     @Shadow

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/RebuildTaskMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/integration/mixins/RebuildTaskMixin.java
@@ -3,13 +3,14 @@ package dev.anvilcraft.lib.v2.rendering.integration.mixins;
 import dev.anvilcraft.lib.v2.rendering.cachedber.pipeline.RebuildTask;
 import dev.anvilcraft.lib.v2.rendering.integration.IrisSupport;
 import net.irisshaders.iris.vertices.ImmediateState;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RebuildTask.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class RebuildTaskMixin {
     @Inject(
         method = "run",

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GameRendererMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GameRendererMixin.java
@@ -3,13 +3,14 @@ package dev.anvilcraft.lib.v2.rendering.mixins;
 import dev.anvilcraft.lib.v2.rendering.event.MainTargetResizeEvent;
 import net.minecraft.client.renderer.GameRenderer;
 import net.neoforged.fml.ModLoader;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class GameRendererMixin {
 
     @Inject(

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GuiGraphicsExtractorMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GuiGraphicsExtractorMixin.java
@@ -14,6 +14,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix3x2f;
 import org.joml.Matrix3x2fStack;
 import org.jspecify.annotations.Nullable;
@@ -23,7 +24,7 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @SuppressWarnings("AddedMixinMembersNamePattern")
 @Mixin(GuiGraphicsExtractor.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class GuiGraphicsExtractorMixin implements GuiGraphicsExtractorExtension {
 
     @Shadow

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GuiRendererMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/GuiRendererMixin.java
@@ -17,6 +17,7 @@ import net.minecraft.client.renderer.state.gui.GuiElementRenderState;
 import net.minecraft.client.renderer.state.gui.GuiItemRenderState;
 import net.minecraft.client.renderer.state.gui.GuiRenderState;
 import net.minecraft.util.ARGB;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -29,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 @Mixin(GuiRenderer.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class GuiRendererMixin {
     @Unique
     private GuiElementRenderState anvillib$renderState = null;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/ItemStackRenderStateMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/ItemStackRenderStateMixin.java
@@ -2,11 +2,12 @@ package dev.anvilcraft.lib.v2.rendering.mixins;
 
 import dev.anvilcraft.lib.v2.rendering.internal.ItemStackRenderStateInternals;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(ItemStackRenderState.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class ItemStackRenderStateMixin implements ItemStackRenderStateInternals.Extension {
     @Unique
     private float anvillib_rendering$alpha = 1f;

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/MinecraftMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/MinecraftMixin.java
@@ -6,6 +6,7 @@ import dev.anvilcraft.lib.v2.rendering.cachedber.pipeline.CachedBlockEntityRende
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.main.GameConfig;
 import net.minecraft.client.multiplayer.ClientLevel;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -14,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Minecraft.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class MinecraftMixin {
 
     @Shadow

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/RenderTypeMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/RenderTypeMixin.java
@@ -2,11 +2,12 @@ package dev.anvilcraft.lib.v2.rendering.mixins;
 
 import dev.anvilcraft.lib.v2.rendering.extension.ALRRenderTypeExtension;
 import net.minecraft.client.renderer.rendertype.RenderType;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(RenderType.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class RenderTypeMixin implements ALRRenderTypeExtension {
 
     @Unique

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/CommandEncoderMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/CommandEncoderMixin.java
@@ -7,12 +7,13 @@ import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.ALRCommandEncoderBacken
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.ALRCommandEncoderExtension;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.MemoryBarrierFlag;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.pipeline.ALRComputePass;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(CommandEncoder.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class CommandEncoderMixin implements ALRCommandEncoderExtension {
     @Shadow
     @Final

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/GpuDeviceMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/GpuDeviceMixin.java
@@ -7,6 +7,7 @@ import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.ALRGpuDeviceExtension;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.pipeline.ALRComputePass;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstance;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstanceKey;
+import org.jetbrains.annotations.ApiStatus;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -14,7 +15,7 @@ import org.spongepowered.asm.mixin.Unique;
 
 @SuppressWarnings("AddedMixinMembersNamePattern")
 @Mixin(GpuDevice.class)
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class GpuDeviceMixin implements ALRGpuDeviceExtension {
     @Shadow
     @Final

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/DirectStateAccessMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/DirectStateAccessMixin.java
@@ -1,13 +1,14 @@
 package dev.anvilcraft.lib.v2.rendering.mixins.blaze3d.gl;
 
 import dev.anvilcraft.lib.v2.rendering.foundation.buffers.GpuBufferConstants;
+import org.jetbrains.annotations.ApiStatus;
 import org.lwjgl.opengl.ARBShaderStorageBufferObject;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class DirectStateAccessMixin {
 
     @Mixin(targets = "com.mojang.blaze3d.opengl.DirectStateAccess$Emulated")

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlCommandEncoderMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlCommandEncoderMixin.java
@@ -9,6 +9,7 @@ import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.ALRGpuDeviceBackendExte
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.MemoryBarrierFlag;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.pipeline.ALRComputePass;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.pipeline.gl.GlComputePassBackend;
+import org.jetbrains.annotations.ApiStatus;
 import org.lwjgl.opengl.ARBComputeShader;
 import org.lwjgl.opengl.ARBShaderImageLoadStore;
 import org.lwjgl.opengl.GL46;
@@ -17,7 +18,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(targets = "com.mojang.blaze3d.opengl.GlCommandEncoder")
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class GlCommandEncoderMixin implements ALRCommandEncoderBackendExtension {
     @Shadow
     @Final

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlDebugLabelMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlDebugLabelMixin.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.opengl.GlDebugLabel;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.ALRDebugLabelExtension;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstance;
 import net.minecraft.util.StringUtil;
+import org.jetbrains.annotations.ApiStatus;
 import org.lwjgl.opengl.EXTDebugLabel;
 import org.lwjgl.opengl.GL46;
 import org.lwjgl.opengl.KHRDebug;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class GlDebugLabelMixin {
     @Mixin(GlDebugLabel.class)
     public static class Self implements ALRDebugLabelExtension {

--- a/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlDeviceMixin.java
+++ b/module.rendering/src/main/java/dev/anvilcraft/lib/v2/rendering/mixins/blaze3d/gl/GlDeviceMixin.java
@@ -6,6 +6,7 @@ import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.ALRDebugLabelEx
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstance;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeProgramInstanceKey;
 import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.shader.ALRComputeShaderManager;
+import org.jetbrains.annotations.ApiStatus;
 import org.lwjgl.opengl.ARBComputeShader;
 import org.lwjgl.opengl.GL46;
 import org.slf4j.Logger;
@@ -14,7 +15,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(targets = "com.mojang.blaze3d.opengl.GlDevice")
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public abstract class GlDeviceMixin implements ALRGpuDeviceBackendExtension {
 
     @Shadow

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/LazySyncBytecodeInjector.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/LazySyncBytecodeInjector.java
@@ -1,6 +1,7 @@
 package dev.anvilcraft.lib.v2.sync.transform;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.ApiStatus;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -32,7 +33,7 @@ import java.util.function.Supplier;
  * 每 tick 扫描差分，故此处无需注入任何字段写入拦截。</p>
  */
 @Slf4j
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class LazySyncBytecodeInjector {
     private static final String LAZY_SYNC_DESC = "Ldev/anvilcraft/lib/v2/sync/annotation/LazySync;";
     private static final String ANVIL_LIB_SYNC_INTERNAL = "dev/anvilcraft/lib/v2/sync/AnvilLibSync";

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/LazySyncTargetIndex.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/LazySyncTargetIndex.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
 import net.neoforged.neoforgespi.language.ModFileScanData;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.annotation.ElementType;
 import java.util.HashSet;
@@ -19,7 +20,7 @@ import java.util.Set;
  * 通过反射读取，故此处仅需记录类的集合。</p>
  */
 @Slf4j
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class LazySyncTargetIndex {
     public static final String LAZY_SYNC_DESCRIPTOR = "Ldev/anvilcraft/lib/v2/sync/annotation/LazySync;";
     private static final Set<String> TARGETS = new HashSet<>();

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncBytecodeInjector.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncBytecodeInjector.java
@@ -1,6 +1,7 @@
 package dev.anvilcraft.lib.v2.sync.transform;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.ApiStatus;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -28,7 +29,7 @@ import java.util.function.Supplier;
  * Static fields    → proxy.setParent(Owner.class) in <clinit> (created if absent)
  */
 @Slf4j
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class SyncBytecodeInjector {
     private static final String SYNC_PROXY_DESC = "Ldev/anvilcraft/lib/v2/sync/management/SyncProxy;";
     private static final String SYNC_PROXY_INTERNAL = "dev/anvilcraft/lib/v2/sync/management/SyncProxy";

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncClassProcessor.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncClassProcessor.java
@@ -3,11 +3,12 @@ package dev.anvilcraft.lib.v2.sync.transform;
 import lombok.extern.slf4j.Slf4j;
 import net.neoforged.neoforgespi.transformation.ClassProcessor;
 import net.neoforged.neoforgespi.transformation.ProcessorName;
+import org.jetbrains.annotations.ApiStatus;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 
 @Slf4j
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class SyncClassProcessor implements ClassProcessor {
     @Override
     public ProcessorName name() {

--- a/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncTargetIndex.java
+++ b/module.sync/processor/src/main/java/dev/anvilcraft/lib/v2/sync/transform/SyncTargetIndex.java
@@ -4,13 +4,14 @@ import lombok.extern.slf4j.Slf4j;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
 import net.neoforged.neoforgespi.language.ModFileScanData;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.annotation.ElementType;
 import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public class SyncTargetIndex {
     public static final String SYNC_DESCRIPTOR = "Ldev/anvilcraft/lib/v2/sync/annotation/Sync;";
     private static final Map<String, String> TARGETS = new HashMap<>();

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/LazySyncPayload.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/LazySyncPayload.java
@@ -18,6 +18,7 @@ import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +41,7 @@ import java.util.List;
  * </pre>
  */
 @Slf4j
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public record LazySyncPayload(
     byte[] array
 ) implements IInsensitiveBiPacket {

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncConfigurationPayload.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncConfigurationPayload.java
@@ -9,11 +9,12 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public record SyncConfigurationPayload(
     Map<Integer, String> syncMap
 ) implements IClientboundPacket {

--- a/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncPayload.java
+++ b/module.sync/src/main/java/dev/anvilcraft/lib/v2/sync/network/payload/SyncPayload.java
@@ -18,11 +18,12 @@ import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.reflect.Field;
 import java.util.Objects;
 
-@org.jetbrains.annotations.ApiStatus.Internal
+@ApiStatus.Internal
 public record SyncPayload(
     byte[] array
 ) implements IInsensitiveBiPacket {


### PR DESCRIPTION
- 将所有@org.jetbrains.annotations.ApiStatus.Internal替换为@ApiStatus.Internal
- 在多个Java文件中添加org.jetbrains.annotations.ApiStatus的导入声明
- 修复RegistrumRecipeProvider中的@Nullable注解引用路径
- 优化SdfTextLayout中LinkedHashMap的导入和使用方式
- 简化SdfTextRenderer中ALFont类的引用路径