### PR TITLE
feat(wheel): 重做环扇模式轮盘渲染

### DIFF
--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/AnvilLibTestClient.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/AnvilLibTestClient.java
@@ -3,7 +3,6 @@ package dev.anvilcraft.lib.v2.test.client;
 import com.mojang.brigadier.arguments.FloatArgumentType;
 import dev.anvilcraft.lib.v2.rendering.cachedber.renderer.CachedBlockEntityRenderDispatcher;
 import dev.anvilcraft.lib.v2.rendering.event.MainTargetResizeEvent;
-import dev.anvilcraft.lib.v2.rendering.extension.blaze3d.compute.ALRComputeCapabilities;
 import dev.anvilcraft.lib.v2.test.AnvilLibTest;
 import dev.anvilcraft.lib.v2.test.all.TestTiles;
 import dev.anvilcraft.lib.v2.test.client.cber.TestCachedRenderer;
@@ -50,17 +49,11 @@ public class AnvilLibTestClient {
 
     @SubscribeEvent
     public static void on(MainTargetResizeEvent event) {
-        if (!ALRComputeCapabilities.isComputeSupported()) {
-            return;
-        }
         ComputeSupport.INSTANCE.resize(event.getNewWidth(), event.getNewHeight());
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void on(RenderLevelStageEvent.AfterLevel level) {
-        if (!ALRComputeCapabilities.isComputeSupported()) {
-            return;
-        }
         ComputeSupport.INSTANCE.computeBlur();
     }
 

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/compute/ComputeSupport.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/compute/ComputeSupport.java
@@ -31,20 +31,10 @@ import java.util.List;
 import java.util.OptionalDouble;
 
 public class ComputeSupport {
-    public static final ComputeSupport INSTANCE;
+    public static final ComputeSupport INSTANCE = new ComputeSupport();
     public static final float[] UNSUPPORTED = {};
     @Getter
     private final GpuDevice device = RenderSystem.getDevice();
-
-    static {
-        ComputeSupport instance;
-        if (ALRComputeCapabilities.isComputeSupported()) {
-            instance = new ComputeSupport();
-        } else {
-            instance = null;
-        }
-        INSTANCE = instance;
-    }
 
     private final GpuBuffer addInputSSBO = device.createBuffer(
         () -> "Test Compute Input SSBO",
@@ -154,7 +144,7 @@ public class ComputeSupport {
         ByteBuffer counterData = mappedCounterBuffer.data();
 
         int anInt = counterData.getInt();
-        if (anInt != input.length) {
+        if (anInt != input.length){
             System.out.printf("Compute counter does not match with input size: %d/%d%n", anInt, input.length);
         }
         return result;
@@ -249,6 +239,5 @@ public class ComputeSupport {
 
 
     public static void init() {
-
     }
 }

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/screen/GuiTestScreen.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/client/screen/GuiTestScreen.java
@@ -223,10 +223,6 @@ public class GuiTestScreen extends Screen {
             ex.printStackTrace();
         }
 
-        if (!ALRComputeCapabilities.isComputeSupported()) {
-            return;
-        }
-
         GpuSampler sampler = ComputeSupport.INSTANCE.getTheSampler();
         int scaledWidth = Minecraft.getInstance().getWindow().getGuiScaledWidth();
         int scaledHeight = Minecraft.getInstance().getWindow().getGuiScaledHeight();

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/mixin/MinecraftMixin.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/mixin/MinecraftMixin.java
@@ -29,9 +29,6 @@ public class MinecraftMixin {
         at = @At("RETURN")
     )
     private void onCreateInstance(GameConfig gameConfig, CallbackInfo ci) {
-        if (ALRComputeCapabilities.isComputeSupported()) {
-            return;
-        }
         ComputeSupport.init();
     }
 

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/wheel/WheelDemoMenus.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/wheel/WheelDemoMenus.java
@@ -17,26 +17,50 @@ public final class WheelDemoMenus {
             .slotsPerPage(slotsPerPage)
             .selectionEffect(selectionEffect)
             .action(
-                "action_1", Component.literal("Action 1"), ctx -> {
+                "action_1", Component.literal("Action 1"), WheelDemoMenus::render, ctx -> {
                 }
             )
             .action(
-                "action_2", Component.literal("Action 2"), ctx -> {
+                "action_2", Component.literal("Action 2"), WheelDemoMenus::render, ctx -> {
                 }
             )
             .submenu(
-                "tools", Component.literal("Tools"), submenu -> submenu
+                "tools", Component.literal("Tools"), WheelDemoMenus::render, submenu -> submenu
                     .action(
-                        "tool_a", Component.literal("Tool A"), ctx -> {
+                        "tool_a", Component.literal("Tool A"), WheelDemoMenus::render, ctx -> {
                         }
                     )
                     .action(
-                        "tool_b", Component.literal("Tool B"), ctx -> {
+                        "tool_b", Component.literal("Tool B"), WheelDemoMenus::render, ctx -> {
                         }
                     )
             )
             .action(
-                "action_3", Component.literal("Action 3"), ctx -> {
+                "action_3", Component.literal("Action 3"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "action_4", Component.literal("Action 4"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "action_5", Component.literal("Action 5"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "action_6", Component.literal("Action 6"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "action_7", Component.literal("Action 7"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "action_8", Component.literal("Action 8"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "action_9", Component.literal("Action 9"), WheelDemoMenus::render, ctx -> {
                 }
             )
             .build();
@@ -50,6 +74,30 @@ public final class WheelDemoMenus {
                 "hold_1", Component.literal("Hold 1"), WheelDemoMenus::render, ctx -> {
                 }
             )
+            .action(
+                "hold_2", Component.literal("Hold 2"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "hold_3", Component.literal("Hold 3"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "hold_4", Component.literal("Hold 4"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "hold_5", Component.literal("Hold 5"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "hold_6", Component.literal("Hold 6"), WheelDemoMenus::render, ctx -> {
+                }
+            )
+            .action(
+                "hold_7", Component.literal("Hold 7"), WheelDemoMenus::render, ctx -> {
+                }
+            )
             .submenu(
                 "ignored_submenu", Component.literal("Ignored Submenu"), WheelDemoMenus::render, submenu -> submenu
                     .action(
@@ -58,7 +106,7 @@ public final class WheelDemoMenus {
                     )
             )
             .action(
-                "hold_2", Component.literal("Hold 2"), WheelDemoMenus::render, ctx -> {
+                "hold_8", Component.literal("Hold 8"), WheelDemoMenus::render, ctx -> {
                 }
             )
             .build();
@@ -68,4 +116,3 @@ public final class WheelDemoMenus {
         graphics.item(Items.APPLE.getDefaultInstance(), -8, -8);
     }
 }
-

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/component/WheelFrostedBackground.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/component/WheelFrostedBackground.java
@@ -1,0 +1,79 @@
+package dev.anvilcraft.lib.v2.wheel.client.gui.component;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.AddressMode;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuSampler;
+import com.mojang.blaze3d.textures.GpuTexture;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import dev.anvilcraft.lib.v2.rendering.blur.GaussianBlur;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.render.TextureSetup;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.OptionalDouble;
+import javax.annotation.Nullable;
+
+/**
+ * 轮盘毛玻璃盘面背景：每帧对主渲染目标做一次高斯模糊，供盘面着色器采样。
+ * 模糊结果纹理对象是复用的，因此只创建一次纹理视图。
+ */
+@ApiStatus.Internal
+public final class WheelFrostedBackground implements AutoCloseable {
+    private final GaussianBlur blur = new GaussianBlur(2.0f, 1.0f);
+    private final GpuSampler sampler = RenderSystem.getDevice().createSampler(
+        AddressMode.CLAMP_TO_EDGE,
+        AddressMode.CLAMP_TO_EDGE,
+        FilterMode.LINEAR,
+        FilterMode.LINEAR,
+        1,
+        OptionalDouble.empty()
+    );
+
+    private int width;
+    private int height;
+    @Nullable
+    private GpuTexture blurredTexture;
+    @Nullable
+    private GpuTextureView blurredTextureView;
+
+    /**
+     * 对当前主渲染目标执行模糊，并返回绑定模糊结果的纹理设置。
+     *
+     * @return 可直接用于 GUI 元素渲染的 TextureSetup
+     */
+    public TextureSetup capture() {
+        RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
+        this.guardSize(mainTarget);
+        GpuTexture blurred = this.blur.process(mainTarget.getColorTexture());
+        if (this.blurredTextureView == null || this.blurredTexture != blurred) {
+            if (this.blurredTextureView != null) {
+                this.blurredTextureView.close();
+            }
+            this.blurredTexture = blurred;
+            this.blurredTextureView = RenderSystem.getDevice().createTextureView(blurred);
+        }
+        return TextureSetup.singleTexture(this.blurredTextureView, this.sampler);
+    }
+
+    private void guardSize(RenderTarget mainTarget) {
+        if (mainTarget.width == this.width && mainTarget.height == this.height) {
+            return;
+        }
+        this.width = mainTarget.width;
+        this.height = mainTarget.height;
+        this.blur.resize(this.width, this.height);
+    }
+
+    @Override
+    public void close() {
+        this.sampler.close();
+        if (this.blurredTextureView != null) {
+            this.blurredTextureView.close();
+            this.blurredTextureView = null;
+        }
+        this.blurredTexture = null;
+        this.blur.close();
+    }
+}

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/component/WheelWidget.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/component/WheelWidget.java
@@ -314,7 +314,7 @@ public class WheelWidget extends AbstractWidget {
             float rotation = MathUtil.clampWithProportion((degreeEachRotation * i + degreeOffsetAngle) % 360, 0, 360);
             Vector2f rotated = MathUtil.rotationDegrees(ROTATION_START, rotation)
                 .mul(1, -1)
-                .mul(this.getSectionCircleDiameter())
+                .mul(this.getSectionCircleRadius())
                 .add(this.centerPos);
             float detectionStart = (float) (Math.toRadians(rotation - degreeEachRotation / 2f) + Math.PI * 2);
             float detectionEnd = (float) (Math.toRadians(rotation + degreeEachRotation / 2f) + Math.PI * 2);
@@ -328,7 +328,7 @@ public class WheelWidget extends AbstractWidget {
                 section
             ));
         }
-        this.selectionEffectPos = MathUtil.rotate(MathUtil.copy(ROTATION_START).mul(this.getSectionCircleDiameter()), this.currentAngle);
+        this.selectionEffectPos = MathUtil.rotate(MathUtil.copy(ROTATION_START).mul(this.getSectionCircleRadius()), this.currentAngle);
     }
 
     public void renderDisc(
@@ -472,7 +472,7 @@ public class WheelWidget extends AbstractWidget {
         if (!this.sections.get(index).selectable()) return this;
         this.setCurrentSectionIndex(index);
         this.currentAngle = this.sections.get(index).angle;
-        this.selectionEffectPos = MathUtil.rotate(MathUtil.copy(ROTATION_START).mul(this.getSectionCircleDiameter()), this.currentAngle);
+        this.selectionEffectPos = MathUtil.rotate(MathUtil.copy(ROTATION_START).mul(this.getSectionCircleRadius()), this.currentAngle);
         return this;
     }
 
@@ -481,7 +481,7 @@ public class WheelWidget extends AbstractWidget {
         return this;
     }
 
-    public float getSectionCircleDiameter() {
+    public float getSectionCircleRadius() {
         // 图标圆心所在圆周的半径：分隔圆环与盘面外缘之间扇区的中间位置
         return (this.ringOuterRadius + this.ringInnerRadius) * 0.5f;
     }
@@ -650,22 +650,24 @@ public class WheelWidget extends AbstractWidget {
             if (this.selectionEffect == WheelSelectionEffect.ANNULAR_SECTOR) {
                 WheelSection section = this.sections.get(this.currentSectionIndex);
                 float rangeAngle = this.normalizePositiveAngle(section.angleEnd - section.angleStart) / 2.0f;
+                float settle = this.settleProgress();
+                float expand = settle * SETTLE_EXPAND;
                 this.renderAnnularSectorSelection(
                     guiGraphics,
                     this.centerPos.x,
                     this.centerPos.y,
-                    this.selectionEffectColor,
-                    (this.ringInnerRadius + SECTION_INNER_INSET) * progress,
-                    (this.ringOuterRadius - SECTION_OUTER_INSET) * progress,
+                    this.getSelectionSectorColor(settle),
+                    (this.ringInnerRadius + SECTION_INNER_INSET + expand) * progress,
+                    (this.ringOuterRadius - SECTION_OUTER_INSET + expand) * progress,
                     section.angle,
                     rangeAngle
                 );
             } else {
                 WheelSection section = this.sections.get(this.currentSectionIndex);
                 Vector2f center = new Vector2f(
-                    (section.center.x - this.centerPos.x) / this.getSectionCircleDiameter(),
-                    (section.center.y - this.centerPos.y) / this.getSectionCircleDiameter()
-                ).mul(this.getSectionCircleDiameter() * progress).add(this.centerPos.x, this.centerPos.y);
+                    (section.center.x - this.centerPos.x) / this.getSectionCircleRadius(),
+                    (section.center.y - this.centerPos.y) / this.getSectionCircleRadius()
+                ).mul(this.getSectionCircleRadius() * progress).add(this.centerPos.x, this.centerPos.y);
                 this.renderSelectionEffect(
                     guiGraphics,
                     center.x,
@@ -677,9 +679,9 @@ public class WheelWidget extends AbstractWidget {
         }
         for (WheelSection value : this.sections) {
             Vector2f center = new Vector2f(
-                (value.center.x - this.centerPos.x) / this.getSectionCircleDiameter(),
-                (value.center.y - this.centerPos.y) / this.getSectionCircleDiameter()
-            ).mul(this.getSectionCircleDiameter() * progress).add(this.centerPos.x, this.centerPos.y);
+                (value.center.x - this.centerPos.x) / this.getSectionCircleRadius(),
+                (value.center.y - this.centerPos.y) / this.getSectionCircleRadius()
+            ).mul(this.getSectionCircleRadius() * progress).add(this.centerPos.x, this.centerPos.y);
             float x = center.x;
             float y = center.y;
             var renderer = value.renderer();
@@ -745,21 +747,28 @@ public class WheelWidget extends AbstractWidget {
 
         float rangeAngle = this.normalizePositiveAngle(currentSection.angleEnd - currentSection.angleStart) / 2.0f;
         // 鼠标停住后，扇区内外缘同步向外扩张一小段距离（外缘最终贴合盘面外边缘），
-        // 同时透明度从 50% 平滑提升到 100%
+        // 同时透明度从 20% 平滑提升到 100%
         float settle = this.settleProgress();
         float expand = settle * SETTLE_EXPAND;
-        int alpha = Math.round(((this.selectionEffectColor >>> 24) & 0xFF) * (0.2f + 0.8f * settle));
-        int sectorColor = (alpha << 24) | (this.selectionEffectColor & 0xFFFFFF);
         this.renderAnnularSectorSelection(
             guiGraphics,
             this.centerPos.x,
             this.centerPos.y,
-            sectorColor,
+            this.getSelectionSectorColor(settle),
             this.ringInnerRadius + SECTION_INNER_INSET + expand,
             this.ringOuterRadius - SECTION_OUTER_INSET + expand,
             this.selectionAngleRad,
             rangeAngle
         );
+    }
+
+    /**
+     * 根据停住动画进度计算环扇高亮色：基础透明度为 20%，停住后平滑升至配置颜色的透明度。
+     */
+    private int getSelectionSectorColor(float settle) {
+        int baseAlpha = (this.selectionEffectColor >>> 24) & 0xFF;
+        int alpha = Math.round(baseAlpha * (0.2f + 0.8f * settle));
+        return (alpha << 24) | (this.selectionEffectColor & 0xFFFFFF);
     }
 
     /**

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/component/WheelWidget.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/component/WheelWidget.java
@@ -6,14 +6,17 @@ import dev.anvilcraft.lib.v2.rendering.sdf.SdfGraphics;
 import dev.anvilcraft.lib.v2.wheel.AnvilLibWheel;
 import dev.anvilcraft.lib.v2.wheel.api.WheelSelectionEffect;
 import dev.anvilcraft.lib.v2.wheel.client.gui.render.state.AnnularSectorRenderState;
+import dev.anvilcraft.lib.v2.wheel.client.gui.render.state.FrostedDiscRenderState;
 import dev.anvilcraft.lib.v2.util.MathUtil;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
 import org.joml.Matrix3x2fStack;
 import org.joml.Vector2f;
 
@@ -22,6 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
+@Slf4j
 @SuppressWarnings(
     {
         "UnusedReturnValue",
@@ -34,9 +38,30 @@ public class WheelWidget extends AbstractWidget {
     private static final float SELECTION_DOT_DIAMETER_RATIO = 0.9f;
     private static final float TAU = (float) (Math.PI * 2.0);
     private static final float ANGLE_AA_RAD = 0.06f;
-    private static final float RING_Z = 60f;
-    private static final float SELECTION_Z = 80f;
     private static final Vector2f ROTATION_START = new Vector2f(0, 1);
+    // 中心区域与扇区之间的白色不透明分隔圆环：半径在中心区基础上外扩的距离与线宽
+    // （SdfGraphics.stroke 实际厚度为入参一半）
+    private static final float SEPARATOR_RING_GAP = 4f;
+    private static final float SEPARATOR_RING_THICKNESS = 4f;
+    // 高亮扇区内缘相对中心区的内缩量（贴合分隔圆环外侧）
+    private static final float SECTION_INNER_INSET = 8f;
+    // 未停住时高亮扇区外缘相对盘面外边缘的内缩量；停住后内外缘同步外扩 SETTLE_EXPAND 距离
+    private static final float SECTION_OUTER_INSET = 2f;
+    // 鼠标停住后高亮扇区内外缘同步向外扩张的距离与动画参数
+    private static final float SETTLE_EXPAND = 2f;
+    private static final long SETTLE_DELAY_MS = 500L;
+    private static final long SETTLE_ANIM_MS = 200L;
+    // 指向鼠标方向的尖括号箭头（贴在分隔圆环内侧）尺寸与线宽
+    private static final float HOVER_CHEVRON_SIZE = 9f;
+    private static final float HOVER_CHEVRON_THICKNESS = 8f;
+    private static final float HOVER_CHEVRON_RING_GAP = 4f;
+    // 中心悬停名缩放倍率
+    private static final float CENTER_TITLE_SCALE = 1.4f;
+    // 翻页箭头（尖括号）尺寸与线宽
+    private static final float CHEVRON_SIZE = 8f;
+    private static final float CHEVRON_THICKNESS = 6f;
+    // 毛玻璃盘面叠加色：白 * 40% 透明度，混合在深色盘面上
+    private static final int FROSTED_TINT = 0x66FFFFFF;
 
     private final Minecraft minecraft = Minecraft.getInstance();
     private final Vector2f centerPos;
@@ -56,6 +81,13 @@ public class WheelWidget extends AbstractWidget {
     private float currentAngle = 0;
     @Getter
     private int currentSectionIndex = -1;
+    // 环扇高亮当前渲染角度（弧度，轮盘坐标系），每帧向目标扇区平滑逼近
+    private float selectionAngleRad = 0;
+    // 最近一次选中扇区变化的时间，用于“鼠标停住”检测
+    private long selectionChangeTime = System.currentTimeMillis();
+    // 鼠标相对轮盘中心的方向角（弧度，与 WheelSection.angle 同坐标系），在死区内时为 null
+    @Nullable
+    private Float mouseAngleRad;
     private Vector2f selectionEffectPos;
     private boolean animationStarted = false;
     @Getter
@@ -63,6 +95,10 @@ public class WheelWidget extends AbstractWidget {
     private boolean closingAnimationStarted = false;
     private final int deadZone;
     private WheelSelectionEffect selectionEffect = WheelSelectionEffect.DOT;
+    @Nullable
+    private WheelFrostedBackground frostedBackground;
+    private boolean hasPreviousPage;
+    private boolean hasNextPage;
 
     public WheelWidget(
         int x,
@@ -295,62 +331,66 @@ public class WheelWidget extends AbstractWidget {
         this.selectionEffectPos = MathUtil.rotate(MathUtil.copy(ROTATION_START).mul(this.getSectionCircleDiameter()), this.currentAngle);
     }
 
-    public void renderRing(
+    public void renderDisc(
         GuiGraphicsExtractor guiGraphics,
-        float centerX,
-        float centerY,
-        int color,
-        float innerDiameter,
-        float outerDiameter,
-        float mouseX,
-        float mouseY
+        float progress
     ) {
-        var width = outerDiameter - innerDiameter;
-        var radius = outerDiameter - width * 0.5f;
-
-        SdfGraphics ring = SdfGraphics.getInstance()
+        SdfGraphics.getInstance()
             .reset()
             .center(true)
-            .circle(
-                centerX,
-                centerY,
-                radius
-            )
-            .stroke(width * 2f);
-
-        if (!ring.collide(mouseX, mouseY, 0.5f)) {
-            ring.color(color);
-        }
-
-        ring.fill()
+            .color(this.ringColor)
+            .circle(this.centerPos.x, this.centerPos.y, this.getDiscRadius() * progress)
+            .fill()
             .draw(guiGraphics);
     }
 
-    public void renderRing(
+    public void renderFrostedBackground(
         GuiGraphicsExtractor guiGraphics,
-        float centerX,
-        float centerY,
-        int color,
-        float innerDiameter,
-        float outerDiameter
+        float progress
     ) {
+        if (this.frostedBackground == null) {
+            return;
+        }
+        try {
+            Window window = this.minecraft.getWindow();
+            float guiScale = (float) window.getGuiScale();
+            float radius = this.getDiscRadius() * progress * guiScale;
+            if (radius <= 0) {
+                return;
+            }
+            GpuBufferSlice writeUniform = AnvilLibWheel.getLibDynamicUniforms().writeFrostedDisc(
+                new Vector2f(window.getWidth(), window.getHeight()),
+                new Vector2f(this.centerPos.x * guiScale, this.centerPos.y * guiScale),
+                radius,
+                1.25f
+            );
+            guiGraphics.submitGuiElementRenderState(new FrostedDiscRenderState(
+                guiGraphics.pose(),
+                0,
+                0,
+                window.getGuiScaledWidth(),
+                window.getGuiScaledHeight(),
+                FROSTED_TINT,
+                writeUniform,
+                this.frostedBackground.capture(),
+                guiGraphics.peekScissorStack()
+            ));
+        } catch (Exception e) {
+            log.error("Wheel frosted background failed to render", e);
+        }
+    }
 
-        var width = outerDiameter - innerDiameter;
-        var radius = outerDiameter - width * 0.5f;
-
-        SdfGraphics ring = SdfGraphics.getInstance()
+    public void renderSeparatorRing(
+        GuiGraphicsExtractor guiGraphics,
+        float progress
+    ) {
+        SdfGraphics.getInstance()
             .reset()
             .center(true)
-            .color(0x99111111)
-            .circle(
-                centerX,
-                centerY,
-                radius
-            )
-            .stroke(width * 2f);
-
-
-        ring.fill()
+            .color(0xFFFFFFFF)
+            .circle(this.centerPos.x, this.centerPos.y, (this.ringInnerRadius + SEPARATOR_RING_GAP) * progress)
+            .stroke(SEPARATOR_RING_THICKNESS)
+            .fill()
             .draw(guiGraphics);
     }
 
@@ -371,24 +411,24 @@ public class WheelWidget extends AbstractWidget {
         float centerX,
         float centerY,
         int color,
-        float innerDiameter,
-        float outerDiameter,
+        float innerRadius,
+        float outerRadius,
         float centerAngleRad,
         float rangeAngleRad
     ) {
-        float outerRadius = outerDiameter + 5;
-        float x1 = centerX - outerRadius;
-        float y1 = centerY - outerRadius;
-        float x2 = centerX + outerRadius;
-        float y2 = centerY + outerRadius;
+        float boundsRadius = outerRadius + 5;
+        float x1 = centerX - boundsRadius;
+        float y1 = centerY - boundsRadius;
+        float x2 = centerX + boundsRadius;
+        float y2 = centerY + boundsRadius;
         Window window = this.minecraft.getWindow();
         float guiScale = (float) window.getGuiScale();
         // Wheel section angle uses "up" as zero; shader atan uses +X as zero.
         float shaderCenterAngle = centerAngleRad + TAU / 4.0f;
         GpuBufferSlice writeUniform = AnvilLibWheel.getLibDynamicUniforms().writeAnnularSector(
             new Vector2f(centerX * guiScale, centerY * guiScale),
-            innerDiameter * guiScale,
-            outerDiameter * guiScale,
+            innerRadius * guiScale,
+            outerRadius * guiScale,
             1.25f,
             ANGLE_AA_RAD,
             shaderCenterAngle,
@@ -416,22 +456,38 @@ public class WheelWidget extends AbstractWidget {
         return this;
     }
 
+    public WheelWidget setFrostedBackground(@Nullable WheelFrostedBackground frostedBackground) {
+        this.frostedBackground = frostedBackground;
+        return this;
+    }
+
+    public WheelWidget setPageState(boolean hasPreviousPage, boolean hasNextPage) {
+        this.hasPreviousPage = hasPreviousPage;
+        this.hasNextPage = hasNextPage;
+        return this;
+    }
+
     public WheelWidget setCurrentIndex(int index) {
         if (index < 0 || index >= this.sections.size()) return this;
         if (!this.sections.get(index).selectable()) return this;
-        this.currentSectionIndex = index;
+        this.setCurrentSectionIndex(index);
         this.currentAngle = this.sections.get(index).angle;
         this.selectionEffectPos = MathUtil.rotate(MathUtil.copy(ROTATION_START).mul(this.getSectionCircleDiameter()), this.currentAngle);
         return this;
     }
 
     public WheelWidget clearSelection() {
-        this.currentSectionIndex = -1;
+        this.setCurrentSectionIndex(-1);
         return this;
     }
 
     public float getSectionCircleDiameter() {
-        return this.ringOuterRadius - this.ringInnerRadius + this.ringInnerRadius * 2;
+        // 图标圆心所在圆周的半径：分隔圆环与盘面外缘之间扇区的中间位置
+        return (this.ringOuterRadius + this.ringInnerRadius) * 0.5f;
+    }
+
+    private float getDiscRadius() {
+        return this.ringOuterRadius;
     }
 
     public int getSectionSize() {
@@ -450,9 +506,9 @@ public class WheelWidget extends AbstractWidget {
         }
 
         if (scrollY > 0) {
-            this.currentSectionIndex = this.findNextSelectableIndex(index, 1);
+            this.setCurrentSectionIndex(this.findNextSelectableIndex(index, 1));
         } else if (scrollY < 0) {
-            this.currentSectionIndex = this.findNextSelectableIndex(index, -1);
+            this.setCurrentSectionIndex(this.findNextSelectableIndex(index, -1));
         }
 
         for (WheelSection section : this.sections) {
@@ -470,22 +526,32 @@ public class WheelWidget extends AbstractWidget {
         float centerY = this.centerPos.y;
         Vector2f cursorPos = new Vector2f((float) mouseX - centerX, (float) mouseY - centerY);
         if (cursorPos.length() < this.deadZone) {
-            this.currentSectionIndex = -1;
+            this.mouseAngleRad = null;
+            this.setCurrentSectionIndex(-1);
             return;
         }
         Vector2f rotationStart = new Vector2f(0, 1);
         cursorPos.normalize();
         double rot = Math.acos(rotationStart.dot(cursorPos) / (rotationStart.length() * cursorPos.length()));
         double rotation = cursorPos.x < 0 ? Math.PI - rot : Math.PI + rot;
+        this.mouseAngleRad = (float) (rotation % (Math.PI * 2));
         for (WheelSection section : this.sections) {
             if ((
                 section.angleStart > section.angleEnd && rotation >= section.angleStart || rotation >= section.angleStart && rotation <= section.angleEnd
             ) && section.selectable) {
                 this.currentAngle = section.angle;
-                this.currentSectionIndex = this.sections.indexOf(section);
+                this.setCurrentSectionIndex(this.sections.indexOf(section));
                 break;
             }
         }
+    }
+
+    private void setCurrentSectionIndex(int index) {
+        if (this.currentSectionIndex == index) {
+            return;
+        }
+        this.currentSectionIndex = index;
+        this.selectionChangeTime = System.currentTimeMillis();
     }
 
     private int findNextSelectableIndex(int start, int direction) {
@@ -534,14 +600,10 @@ public class WheelWidget extends AbstractWidget {
             return;
         }
 
-        this.renderRing(
-            guiGraphics,
-            this.centerPos.x,
-            this.centerPos.y,
-            this.ringColor,
-            this.ringInnerRadius * 2,
-            this.ringOuterRadius * 2
-        );
+        this.renderDisc(guiGraphics, 1f);
+        this.renderFrostedBackground(guiGraphics, 1f);
+        this.renderSeparatorRing(guiGraphics, 1f);
+        this.renderHoverChevron(guiGraphics);
         if (this.currentSectionIndex != -1) {
             this.renderSelection(guiGraphics);
         }
@@ -556,22 +618,9 @@ public class WheelWidget extends AbstractWidget {
                 renderer.render(guiGraphics, poseStack, renderSize, renderSize);
                 poseStack.popMatrix();
             }
-            poseStack.pushMatrix();
-            float coordinateScale = 0.7f;
-            float offsetX = 0.1f * this.width;
-            float offsetY = 0.1f * this.height;
-            float adjustedX = (x - offsetX) / coordinateScale;
-            float adjustedY = renderer == null
-                ? (y - offsetY - (minecraft.font.lineHeight * this.textScale) / 2.0f) / coordinateScale
-                : (y - offsetY - 20 * this.textScale) / coordinateScale;
-
-            poseStack.translate(offsetX, offsetY);
-            poseStack.scale(coordinateScale, coordinateScale);
-            poseStack.translate(adjustedX, adjustedY);
-            poseStack.scale(this.textScale / coordinateScale, this.textScale / coordinateScale);
-            guiGraphics.centeredText(minecraft.font, value.subTitle, 0, 0, (0xff << 24) | this.textColor);
-            poseStack.popMatrix();
         }
+        this.renderCenterTitle(guiGraphics);
+        this.renderPageArrows(guiGraphics);
     }
 
     @Override
@@ -593,14 +642,9 @@ public class WheelWidget extends AbstractWidget {
         if (progress == 0) return;
         Matrix3x2fStack poseStack = guiGraphics.pose();
         poseStack.pushMatrix();
-        this.renderRing(
-            guiGraphics,
-            this.centerPos.x,
-            this.centerPos.y,
-            this.ringColor,
-            this.ringInnerRadius * 2 * progress,
-            this.ringOuterRadius * 2 * progress
-        );
+        this.renderDisc(guiGraphics, progress);
+        this.renderFrostedBackground(guiGraphics, progress);
+        this.renderSeparatorRing(guiGraphics, progress);
         poseStack.popMatrix();
         if (this.currentSectionIndex != -1) {
             if (this.selectionEffect == WheelSelectionEffect.ANNULAR_SECTOR) {
@@ -611,8 +655,8 @@ public class WheelWidget extends AbstractWidget {
                     this.centerPos.x,
                     this.centerPos.y,
                     this.selectionEffectColor,
-                    this.ringInnerRadius * 2 * progress,
-                    this.ringOuterRadius * 2 * progress,
+                    (this.ringInnerRadius + SECTION_INNER_INSET) * progress,
+                    (this.ringOuterRadius - SECTION_OUTER_INSET) * progress,
                     section.angle,
                     rangeAngle
                 );
@@ -646,22 +690,22 @@ public class WheelWidget extends AbstractWidget {
                 renderer.render(guiGraphics, poseStack, renderSize, renderSize);
                 poseStack.popMatrix();
             }
-            final int textAlpha = (int) (progress * 0xff) << 24;
-            poseStack.pushMatrix();
-            float coordinateScale = 0.7f;
-            float offsetX = 0.1f * this.width;
-            float offsetY = 0.1f * this.height;
-            float adjustedX = (x - offsetX) / coordinateScale;
-            float adjustedY = renderer == null
-                ? (y - offsetY - (minecraft.font.lineHeight * this.textScale) / 2.0f) / coordinateScale
-                : (y - offsetY - 20 * this.textScale) / coordinateScale;
-
-            poseStack.translate(offsetX, offsetY);
-            poseStack.scale(coordinateScale, coordinateScale);
-            poseStack.translate(adjustedX, adjustedY);
-            poseStack.scale(this.textScale / coordinateScale, this.textScale / coordinateScale);
-            guiGraphics.centeredText(this.minecraft.font, value.subTitle, 0, 0, textAlpha | 0xfdfdfd);
-            poseStack.popMatrix();
+        }
+        if (this.currentSectionIndex != -1) {
+            WheelSection section = this.sections.get(this.currentSectionIndex);
+            Component title = section.subTitle();
+            if (title != null && !title.getString().isEmpty()) {
+                final int textAlpha = (int) (progress * 0xff) << 24;
+                final int shadowAlpha = (int) (progress * 0x99) << 24;
+                poseStack.pushMatrix();
+                poseStack.translate(this.centerPos.x, this.centerPos.y);
+                float scale = this.textScale * CENTER_TITLE_SCALE;
+                poseStack.scale(scale, scale);
+                int textY = -this.minecraft.font.lineHeight / 2;
+                guiGraphics.centeredText(this.minecraft.font, title, 1, textY + 1, shadowAlpha);
+                guiGraphics.centeredText(this.minecraft.font, title, 0, textY, textAlpha | 0xfdfdfd);
+                poseStack.popMatrix();
+            }
         }
     }
 
@@ -695,22 +739,128 @@ public class WheelWidget extends AbstractWidget {
 
     private void renderSelectionAnnularSector(GuiGraphicsExtractor guiGraphics) {
         WheelSection currentSection = this.sections.get(this.currentSectionIndex);
+        // 渲染角度沿最短路径向目标扇区角度平滑逼近，高亮在两个扇区间滑动
+        float diffAngle = this.normalizeSignedAngle(currentSection.angle - this.selectionAngleRad);
+        this.selectionAngleRad += diffAngle / this.selectionAnimationSpeedFactor;
+
         float rangeAngle = this.normalizePositiveAngle(currentSection.angleEnd - currentSection.angleStart) / 2.0f;
+        // 鼠标停住后，扇区内外缘同步向外扩张一小段距离（外缘最终贴合盘面外边缘），
+        // 同时透明度从 50% 平滑提升到 100%
+        float settle = this.settleProgress();
+        float expand = settle * SETTLE_EXPAND;
+        int alpha = Math.round(((this.selectionEffectColor >>> 24) & 0xFF) * (0.2f + 0.8f * settle));
+        int sectorColor = (alpha << 24) | (this.selectionEffectColor & 0xFFFFFF);
         this.renderAnnularSectorSelection(
             guiGraphics,
             this.centerPos.x,
             this.centerPos.y,
-            this.selectionEffectColor,
-            this.ringInnerRadius * 2,
-            this.ringOuterRadius * 2,
-            currentSection.angle,
+            sectorColor,
+            this.ringInnerRadius + SECTION_INNER_INSET + expand,
+            this.ringOuterRadius - SECTION_OUTER_INSET + expand,
+            this.selectionAngleRad,
             rangeAngle
         );
+    }
+
+    /**
+     * 鼠标停住（选中扇区在 SETTLE_DELAY_MS 内未变化）后，0→1 的平滑外推动画进度。
+     */
+    private float settleProgress() {
+        long elapsed = System.currentTimeMillis() - this.selectionChangeTime;
+        float p = Mth.clamp((elapsed - SETTLE_DELAY_MS) / (float) SETTLE_ANIM_MS, 0.0f, 1.0f);
+        return p * p * (3.0f - 2.0f * p);
+    }
+
+    private float normalizeSignedAngle(float angle) {
+        float normalized = angle % TAU;
+        if (normalized > Math.PI) {
+            normalized -= TAU;
+        } else if (normalized < -Math.PI) {
+            normalized += TAU;
+        }
+        return normalized;
+    }
+
+    private void renderCenterTitle(GuiGraphicsExtractor guiGraphics) {
+        if (this.currentSectionIndex < 0) {
+            return;
+        }
+        WheelSection section = this.sections.get(this.currentSectionIndex);
+        Component title = section.subTitle();
+        if (title == null || title.getString().isEmpty()) {
+            return;
+        }
+        Matrix3x2fStack poseStack = guiGraphics.pose();
+        poseStack.pushMatrix();
+        poseStack.translate(this.centerPos.x, this.centerPos.y);
+        float scale = this.textScale * CENTER_TITLE_SCALE;
+        poseStack.scale(scale, scale);
+        // centeredText 的 y 是文本顶部，向上偏移半个行高使文本垂直居中于轮盘中心
+        int textY = -this.minecraft.font.lineHeight / 2;
+        guiGraphics.centeredText(this.minecraft.font, title, 1, textY + 1, 0x99000000);
+        guiGraphics.centeredText(this.minecraft.font, title, 0, textY, (0xff << 24) | this.textColor);
+        poseStack.popMatrix();
+    }
+
+    private void renderPageArrows(GuiGraphicsExtractor guiGraphics) {
+        if (!this.hasPreviousPage && !this.hasNextPage) {
+            return;
+        }
+        // 左右下角的箭头做轻微的水平浮动动画，提示可以翻页
+        float phase = System.currentTimeMillis() / 1000f;
+        float bob = (float) Math.sin(phase * 2.2f) * 4f;
+        float cornerDist = this.getDiscRadius() * 0.7071f + 26f;
+        float arrowY = this.centerPos.y + cornerDist;
+        float leftX = this.centerPos.x - cornerDist + bob;
+        float rightX = this.centerPos.x + cornerDist - bob;
+        if (this.hasPreviousPage) {
+            this.renderChevron(guiGraphics, leftX, arrowY, CHEVRON_SIZE, 0xFFFFFFFF, true);
+        }
+        if (this.hasNextPage) {
+            this.renderChevron(guiGraphics, rightX, arrowY, CHEVRON_SIZE, 0xFFFFFFFF, false);
+        }
+    }
+
+    private void renderChevron(GuiGraphicsExtractor guiGraphics, float x, float y, float size, int color, boolean pointingLeft) {
+        SdfGraphics sdf = SdfGraphics.getInstance();
+        if (pointingLeft) {
+            sdf.reset().color(color).stroke(CHEVRON_THICKNESS)
+                .segment(x + size, y - size, x - size, y).fill().draw(guiGraphics);
+            sdf.reset().color(color).stroke(CHEVRON_THICKNESS)
+                .segment(x - size, y, x + size, y + size).fill().draw(guiGraphics);
+        } else {
+            sdf.reset().color(color).stroke(CHEVRON_THICKNESS)
+                .segment(x - size, y - size, x + size, y).fill().draw(guiGraphics);
+            sdf.reset().color(color).stroke(CHEVRON_THICKNESS)
+                .segment(x + size, y, x - size, y + size).fill().draw(guiGraphics);
+        }
     }
 
     private float normalizePositiveAngle(float angle) {
         float normalized = angle % TAU;
         return normalized < 0 ? normalized + TAU : normalized;
+    }
+
+    /**
+     * 在分隔圆环内侧渲染一个指向鼠标方向的尖括号箭头。
+     */
+    private void renderHoverChevron(GuiGraphicsExtractor guiGraphics) {
+        if (this.mouseAngleRad == null) {
+            return;
+        }
+        // 与扇区排布同一坐标系换算屏幕方向：正上方为 0
+        Vector2f dir = MathUtil.rotate(MathUtil.copy(ROTATION_START), this.mouseAngleRad).mul(1, -1);
+        Vector2f perp = new Vector2f(-dir.y, dir.x);
+        float tipDist = this.ringInnerRadius - HOVER_CHEVRON_RING_GAP;
+        Vector2f tip = new Vector2f(dir).mul(tipDist).add(this.centerPos);
+        Vector2f base = new Vector2f(dir).mul(tipDist - HOVER_CHEVRON_SIZE).add(this.centerPos);
+        Vector2f wingA = new Vector2f(base).add(new Vector2f(perp).mul(HOVER_CHEVRON_SIZE * 0.8f));
+        Vector2f wingB = new Vector2f(base).add(new Vector2f(perp).mul(-HOVER_CHEVRON_SIZE * 0.8f));
+        SdfGraphics sdf = SdfGraphics.getInstance();
+        sdf.reset().color(0xFFFFFFFF).stroke(HOVER_CHEVRON_THICKNESS)
+            .segment(wingA.x, wingA.y, tip.x, tip.y).fill().draw(guiGraphics);
+        sdf.reset().color(0xFFFFFFFF).stroke(HOVER_CHEVRON_THICKNESS)
+            .segment(wingB.x, wingB.y, tip.x, tip.y).fill().draw(guiGraphics);
     }
 
 

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/render/state/FrostedDiscRenderState.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/render/state/FrostedDiscRenderState.java
@@ -1,0 +1,77 @@
+package dev.anvilcraft.lib.v2.wheel.client.gui.render.state;
+
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import dev.anvilcraft.lib.v2.rendering.state.LibGuiElementRenderState;
+import dev.anvilcraft.lib.v2.rendering.state.LibQuadGuiElementRenderState;
+import dev.anvilcraft.lib.v2.wheel.client.init.LibRenders;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.gui.render.TextureSetup;
+import org.joml.Matrix3x2f;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * 轮盘毛玻璃盘面：采样主渲染目标的高斯模糊结果，并用圆形遮罩裁出盘面区域。
+ * 纹理 V 轴在 GUI 采样时翻转，顶点颜色用于调制模糊内容与叠加透明度。
+ */
+@ApiStatus.Internal
+public record FrostedDiscRenderState(
+    Matrix3x2f pose,
+    float x0,
+    float y0,
+    float x1,
+    float y1,
+    int color,
+    GpuBufferSlice frostedDiscUniform,
+    TextureSetup textureSetup,
+    @Nullable ScreenRectangle scissorArea,
+    @Nullable ScreenRectangle bounds
+) implements LibQuadGuiElementRenderState {
+    public FrostedDiscRenderState(
+        Matrix3x2f pose,
+        float x0,
+        float y0,
+        float x1,
+        float y1,
+        int color,
+        GpuBufferSlice frostedDiscUniform,
+        TextureSetup textureSetup,
+        @Nullable ScreenRectangle scissorArea
+    ) {
+        this(
+            pose,
+            x0,
+            y0,
+            x1,
+            y1,
+            color,
+            frostedDiscUniform,
+            textureSetup,
+            scissorArea,
+            LibGuiElementRenderState.getBounds(pose, x0, y0, x1, y1, scissorArea)
+        );
+    }
+
+    @Override
+    public RenderPipeline pipeline() {
+        return LibRenders.FROSTED_DISC_PIPELINE;
+    }
+
+    @Override
+    public Map<String, GpuBufferSlice> bufferSlices() {
+        return Map.of("FrostedDiscUniform", this.frostedDiscUniform());
+    }
+
+    @Override
+    public void buildVertices(VertexConsumer consumer) {
+        // 渲染目标纹理 v=0 对应画面底部，这里从顶部(GUI y0)开始取 v=1。
+        consumer.addVertexWith2DPose(this.pose(), this.x0(), this.y0()).setUv(0f, 1f).setColor(this.color());
+        consumer.addVertexWith2DPose(this.pose(), this.x0(), this.y1()).setUv(0f, 0f).setColor(this.color());
+        consumer.addVertexWith2DPose(this.pose(), this.x1(), this.y1()).setUv(1f, 0f).setColor(this.color());
+        consumer.addVertexWith2DPose(this.pose(), this.x1(), this.y0()).setUv(1f, 1f).setColor(this.color());
+    }
+}

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/screen/WheelScreen.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/screen/WheelScreen.java
@@ -5,6 +5,7 @@ import dev.anvilcraft.lib.v2.wheel.api.WheelEntry;
 import dev.anvilcraft.lib.v2.wheel.api.WheelMenuModel;
 import dev.anvilcraft.lib.v2.wheel.api.WheelOpenMode;
 import dev.anvilcraft.lib.v2.wheel.api.WheelPageModel;
+import dev.anvilcraft.lib.v2.wheel.client.gui.component.WheelFrostedBackground;
 import dev.anvilcraft.lib.v2.wheel.client.gui.component.WheelWidget;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
@@ -15,10 +16,11 @@ import net.minecraft.network.chat.Component;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public class WheelScreen extends Screen {
-    private static final float WHEEL_INNER_RADIUS_SCALE = 0.12f;
-    private static final float WHEEL_OUTER_RADIUS_SCALE = 0.22f;
+    private static final float WHEEL_INNER_RADIUS_SCALE = 0.17f;
+    private static final float WHEEL_OUTER_RADIUS_SCALE = 0.33f;
 
     private final WheelMenuModel model;
     private final WheelOpenMode openMode;
@@ -26,6 +28,8 @@ public class WheelScreen extends Screen {
 
     private WheelWidget wheelWidget;
     private int currentPageIndex;
+    @Nullable
+    private WheelFrostedBackground frostedBackground;
 
     public WheelScreen(WheelMenuModel model, WheelOpenMode openMode) {
         super(Component.empty());
@@ -54,8 +58,6 @@ public class WheelScreen extends Screen {
         if (this.wheelWidget != null) {
             this.wheelWidget.extractRenderState(guiGraphics, mouseX, mouseY, partialTick);
         }
-        Component pageInfo = Component.literal((this.currentPageIndex + 1) + " / " + this.pageCountForCurrentMenu());
-        guiGraphics.centeredText(this.font, pageInfo, this.width / 2, this.height - 22, 0xFFFFFFFF);
     }
 
     @Override
@@ -84,7 +86,20 @@ public class WheelScreen extends Screen {
 
     @Override
     protected void init() {
+        if (this.frostedBackground != null) {
+            this.frostedBackground.close();
+        }
+        this.frostedBackground = new WheelFrostedBackground();
         this.rebuildWheelWidget();
+    }
+
+    @Override
+    public void removed() {
+        if (this.frostedBackground != null) {
+            this.frostedBackground.close();
+            this.frostedBackground = null;
+        }
+        super.removed();
     }
 
     @Override
@@ -182,6 +197,11 @@ public class WheelScreen extends Screen {
             Math.min(this.width, this.height) * WHEEL_OUTER_RADIUS_SCALE,
             sections,
             this.model.deadZone()
+        );
+        this.wheelWidget.setFrostedBackground(this.frostedBackground);
+        this.wheelWidget.setPageState(
+            this.currentPageIndex > 0,
+            this.currentPageIndex < this.pageCountForCurrentMenu() - 1
         );
         this.wheelWidget.setSelectionEffectColor(this.model.selectionEffectColor());
         this.wheelWidget.setSelectionEffect(this.model.selectionEffect());

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/init/LibDynamicUniforms.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/init/LibDynamicUniforms.java
@@ -36,6 +36,12 @@ public class LibDynamicUniforms {
         GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_COPY_DST
     );
 
+    private final DynamicUniformStorage<FrostedDiscUniform> frostedDiscUbo = new DynamicUniformStorage<>(
+        "FrostedDiscUniform UBO",
+        FrostedDiscUniform.size(),
+        GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_COPY_DST
+    );
+
     public GpuBufferSlice writeRing(Vector2fc center, float innerDiameter, float outerDiameter, float antiAliasingRadius) {
         return this.ringUbo.writeUniform(new RingUniform(
             center,
@@ -56,8 +62,8 @@ public class LibDynamicUniforms {
 
     public GpuBufferSlice writeAnnularSector(
         Vector2fc center,
-        float innerDiameter,
-        float outerDiameter,
+        float innerRadius,
+        float outerRadius,
         float antiAliasingRadius,
         float angleAntiAliasingRad,
         float centerAngleRad,
@@ -65,8 +71,8 @@ public class LibDynamicUniforms {
     ) {
         return this.annularSectorUbo.writeUniform(new AnnularSectorUniform(
             center,
-            innerDiameter,
-            outerDiameter,
+            innerRadius,
+            outerRadius,
             antiAliasingRadius,
             angleAntiAliasingRad,
             centerAngleRad,
@@ -74,10 +80,25 @@ public class LibDynamicUniforms {
         ));
     }
 
+    public GpuBufferSlice writeFrostedDisc(
+        Vector2fc framebufferSize,
+        Vector2fc center,
+        float radius,
+        float antiAliasingRadius
+    ) {
+        return this.frostedDiscUbo.writeUniform(new FrostedDiscUniform(
+            framebufferSize,
+            center,
+            radius,
+            antiAliasingRadius
+        ));
+    }
+
     public void reset() {
         this.ringUbo.endFrame();
         this.selectionUbo.endFrame();
         this.annularSectorUbo.endFrame();
+        this.frostedDiscUbo.endFrame();
     }
 
     @SubscribeEvent
@@ -139,8 +160,8 @@ public class LibDynamicUniforms {
 
     public record AnnularSectorUniform(
         Vector2fc center,
-        float innerDiameter,
-        float outerDiameter,
+        float innerRadius,
+        float outerRadius,
         float antiAliasingRadius,
         float angleAntiAliasingRad,
         float centerAngleRad,
@@ -151,9 +172,9 @@ public class LibDynamicUniforms {
             return new Std140SizeCalculator()
                 // Center
                 .putVec2()
-                // InnerDiameter
+                // InnerRadius
                 .putFloat()
-                // OuterDiameter
+                // OuterRadius
                 .putFloat()
                 // AntiAliasingRadius
                 .putFloat()
@@ -170,12 +191,42 @@ public class LibDynamicUniforms {
         public void write(ByteBuffer buffer) {
             Std140Builder.intoBuffer(buffer)
                 .putVec2(this.center)
-                .putFloat(this.innerDiameter)
-                .putFloat(this.outerDiameter)
+                .putFloat(this.innerRadius)
+                .putFloat(this.outerRadius)
                 .putFloat(this.antiAliasingRadius)
                 .putFloat(this.angleAntiAliasingRad)
                 .putFloat(this.centerAngleRad)
                 .putFloat(this.rangeAngleRad);
+        }
+    }
+
+    public record FrostedDiscUniform(
+        Vector2fc framebufferSize,
+        Vector2fc center,
+        float radius,
+        float antiAliasingRadius
+    ) implements DynamicUniformStorage.DynamicUniform {
+
+        public static int size() {
+            return new Std140SizeCalculator()
+                // FramebufferSize
+                .putVec2()
+                // Center
+                .putVec2()
+                // Radius
+                .putFloat()
+                // AntiAliasingRadius
+                .putFloat()
+                .get();
+        }
+
+        @Override
+        public void write(ByteBuffer buffer) {
+            Std140Builder.intoBuffer(buffer)
+                .putVec2(this.framebufferSize)
+                .putVec2(this.center)
+                .putFloat(this.radius)
+                .putFloat(this.antiAliasingRadius);
         }
     }
 }

--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/init/LibRenders.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/init/LibRenders.java
@@ -40,4 +40,13 @@ public class LibRenders {
         .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS)
         .withUniform("AnnularSectorUniform", UniformType.UNIFORM_BUFFER)
         .build();
+
+    public static final RenderPipeline FROSTED_DISC_PIPELINE = RenderPipeline.builder(SNIPPET_COMMON)
+        .withLocation(AnvilLibWheel.of("pipeline/frosted_disc"))
+        .withVertexShader("core/position_tex_color")
+        .withFragmentShader(AnvilLibWheel.of("core/frosted_disc"))
+        .withVertexFormat(DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS)
+        .withSampler("Sampler0")
+        .withUniform("FrostedDiscUniform", UniformType.UNIFORM_BUFFER)
+        .build();
 }

--- a/module.wheel/src/main/resources/assets/anvillib/shaders/core/annular_sector.fsh
+++ b/module.wheel/src/main/resources/assets/anvillib/shaders/core/annular_sector.fsh
@@ -4,8 +4,9 @@ in vec4 vertexColor;
 
 layout (std140) uniform AnnularSectorUniform {
     vec2 Center;
-    float InnerDiameter;
-    float OuterDiameter;
+    // 注意：以下为半径而非直径（历史命名遗留，调用方按半径传入）
+    float InnerRadius;
+    float OuterRadius;
     float AntiAliasingRadius;
     float AngleAntiAliasingRad;
     float CenterAngleRad;
@@ -48,8 +49,8 @@ void main() {
     float angle = atan(fragPos.y - Center.y, fragPos.x - Center.x);
     float radialAa = max(min(AntiAliasingRadius, fwidth(distance) * 1.5), 0.0001);
 
-    color.a *= smoothstep(InnerDiameter - radialAa, InnerDiameter + radialAa, distance)
-             * (1.0 - smoothstep(OuterDiameter - radialAa, OuterDiameter + radialAa, distance))
+    color.a *= smoothstep(InnerRadius - radialAa, InnerRadius + radialAa, distance)
+             * (1.0 - smoothstep(OuterRadius - radialAa, OuterRadius + radialAa, distance))
              * calcAngleAlpha(angle, CenterAngleRad, RangeAngleRad, AngleAntiAliasingRad);
 
     fragColor = color;

--- a/module.wheel/src/main/resources/assets/anvillib/shaders/core/frosted_disc.fsh
+++ b/module.wheel/src/main/resources/assets/anvillib/shaders/core/frosted_disc.fsh
@@ -1,0 +1,30 @@
+#version 150
+
+in vec2 texCoord0;
+in vec4 vertexColor;
+
+layout (std140) uniform FrostedDiscUniform {
+    vec2 FramebufferSize;
+    vec2 Center;
+    float Radius;
+    float AntiAliasingRadius;
+};
+
+uniform sampler2D Sampler0;
+
+out vec4 fragColor;
+
+void main() {
+    // GUI 渲染通道的 gl_FragCoord 与 GUI 坐标一致（左上角原点，Y 向下）。
+    vec2 fragPos = gl_FragCoord.xy;
+    float dist = distance(fragPos, Center);
+    float aa = max(min(AntiAliasingRadius, fwidth(dist) * 1.5), 0.0001);
+    // 圆形盘面遮罩：半径内可见，边缘抗锯齿过渡。
+    float mask = 1.0 - smoothstep(Radius - aa, Radius + aa, dist);
+
+    // GUI 渲染器以 "Sampler0" 为名绑定 TextureSetup 的第一个纹理
+    vec4 scene = texture(Sampler0, texCoord0);
+
+    // vertexColor 作为毛玻璃着色与混合强度：rgb 调制模糊内容，a 控制叠加透明度。
+    fragColor = vec4(scene.rgb * vertexColor.rgb, mask * vertexColor.a);
+}


### PR DESCRIPTION
- Revert compute support (#92)
- 新增半透明深色圆形盘面与毛玻璃模糊背景（frosted_disc 管线与 WheelFrostedBackground）
- 中心区域与扇区之间绘制白色不透明细圆环分隔
- 中心留白垂直居中显示当前悬停项名称
- 新增贴分隔圆环内侧、指向鼠标方向的尖括号箭头
- 超出一圈容量时左右下角显示左右浮动的尖括号翻页箭头
- 高亮扇区在扇区间平滑滑动，鼠标停住后内外缘同步外扩 2px 且透明度由 50% 升至 100%
- 修正环扇着色器半径语义（InnerRadius/OuterRadius）并放大盘面与中心区尺寸
- 扩充 wheel 演示菜单至 10/9 项并补齐图标渲染器