### PR TITLE
feat(registrum): 增加创造模式标签分区展示支持

### DIFF
--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/builders/CreativeTabBuilder.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/builders/CreativeTabBuilder.java
@@ -25,6 +25,7 @@
 package dev.anvilcraft.lib.v2.registrum.builders;
 
 import dev.anvilcraft.lib.v2.registrum.AbstractRegistrum;
+import dev.anvilcraft.lib.v2.registrum.util.CreativeTabSections;
 import net.minecraft.Util;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
@@ -37,6 +38,7 @@ import net.minecraft.world.level.ItemLike;
 import net.neoforged.neoforge.registries.DeferredHolder;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -84,6 +86,11 @@ public class CreativeTabBuilder<P> extends AbstractBuilder<CreativeModeTab, Crea
     public CreativeTabBuilder<P> displayItems(CreativeModeTab.DisplayItemsGenerator displayItemsGenerator) {
         this.builder = this.builder.displayItems(displayItemsGenerator);
         return this;
+    }
+
+    public CreativeTabBuilder<P> sectionedDisplayItems(Consumer<CreativeTabSections> displayItems) {
+        ResourceLocation tabId = ResourceLocation.fromNamespaceAndPath(this.getOwner().getModid(), this.getName());
+        return this.displayItems((parameters, output) -> CreativeTabSections.build(tabId, parameters, output, displayItems));
     }
 
     public CreativeTabBuilder<P> alignedRight() {

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/mixin/CreativeModeTabMixin.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/mixin/CreativeModeTabMixin.java
@@ -1,0 +1,31 @@
+package dev.anvilcraft.lib.v2.registrum.mixin;
+
+import dev.anvilcraft.lib.v2.registrum.util.CreativeTabSections;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Collection;
+
+@Mixin(CreativeModeTab.class)
+abstract class CreativeModeTabMixin {
+    @Shadow
+    private Collection<ItemStack> displayItems;
+
+    @Inject(method = "buildContents", at = @At("TAIL"))
+    private void anvillib$arrangeSections(
+        CreativeModeTab.ItemDisplayParameters parameters,
+        CallbackInfo ci
+    ) {
+        CreativeModeTab tab = (CreativeModeTab) (Object) this;
+        ResourceLocation tabId = BuiltInRegistries.CREATIVE_MODE_TAB.getKey(tab);
+        if (tabId == null) return;
+        this.displayItems = CreativeTabSections.arrange(tabId, this.displayItems);
+    }
+}

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/mixin/client/CreativeModeInventoryScreenMixin.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/mixin/client/CreativeModeInventoryScreenMixin.java
@@ -1,0 +1,182 @@
+package dev.anvilcraft.lib.v2.registrum.mixin.client;
+
+import dev.anvilcraft.lib.v2.registrum.util.CreativeTabSection;
+import dev.anvilcraft.lib.v2.registrum.util.CreativeTabSections;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.CreativeModeTab;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(CreativeModeInventoryScreen.class)
+abstract class CreativeModeInventoryScreenMixin
+    extends AbstractContainerScreen<CreativeModeInventoryScreen.ItemPickerMenu> {
+    @Unique
+    private static final int anvillib$COLUMN_COUNT = 9;
+    @Unique
+    private static final int anvillib$VISIBLE_ROW_COUNT = 5;
+    @Unique
+    private static final int anvillib$CELL_SIZE = 18;
+    @Unique
+    private static final int anvillib$GRID_LEFT = 9;
+    @Unique
+    private static final int anvillib$GRID_TOP = 18;
+    @Unique
+    private static final int anvillib$BANNER_Z = 200;
+    @Unique
+    private static final int anvillib$TEXT_PADDING = 2;
+
+    @Shadow
+    private static CreativeModeTab selectedTab;
+    @Shadow
+    private float scrollOffs;
+
+    @Unique
+    private CreativeTabSection anvillib$hoveredSection;
+
+    protected CreativeModeInventoryScreenMixin(
+        CreativeModeInventoryScreen.ItemPickerMenu menu,
+        Inventory inventory,
+        Component title
+    ) {
+        super(menu, inventory, title);
+    }
+
+    @Inject(
+        method = "render",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen;"
+                + "renderTooltip(Lnet/minecraft/client/gui/GuiGraphics;II)V"
+        )
+    )
+    private void anvillib$renderSections(
+        GuiGraphics graphics,
+        int mouseX,
+        int mouseY,
+        float partialTick,
+        CallbackInfo ci
+    ) {
+        this.anvillib$hoveredSection = null;
+        if (selectedTab == null || selectedTab.getType() != CreativeModeTab.Type.CATEGORY) return;
+        ResourceLocation tabId = BuiltInRegistries.CREATIVE_MODE_TAB.getKey(selectedTab);
+        if (tabId == null) return;
+        int scrollRow = this.anvillib$scrollRow();
+        for (CreativeTabSections.PlacedSection placedSection : CreativeTabSections.placedSections(tabId)) {
+            this.anvillib$renderSection(graphics, placedSection, scrollRow, mouseX, mouseY);
+        }
+        if (this.anvillib$hoveredSection != null) this.hoveredSlot = null;
+    }
+
+    @Inject(
+        method = "render",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen;"
+                + "renderTooltip(Lnet/minecraft/client/gui/GuiGraphics;II)V",
+            shift = At.Shift.AFTER
+        )
+    )
+    private void anvillib$renderSectionTooltip(
+        GuiGraphics graphics,
+        int mouseX,
+        int mouseY,
+        float partialTick,
+        CallbackInfo ci
+    ) {
+        if (this.anvillib$hoveredSection == null) return;
+        List<Component> tooltip = this.anvillib$hoveredSection.tooltip();
+        if (!tooltip.isEmpty()) graphics.renderComponentTooltip(this.font, tooltip, mouseX, mouseY);
+    }
+
+    @Unique
+    private int anvillib$scrollRow() {
+        int rowCount = (this.menu.items.size() + anvillib$COLUMN_COUNT - 1) / anvillib$COLUMN_COUNT
+            - anvillib$VISIBLE_ROW_COUNT;
+        return Math.max((int) (this.scrollOffs * rowCount + 0.5F), 0);
+    }
+
+    @Unique
+    private void anvillib$renderSection(
+        GuiGraphics graphics,
+        CreativeTabSections.PlacedSection placedSection,
+        int scrollRow,
+        int mouseX,
+        int mouseY
+    ) {
+        CreativeTabSection section = placedSection.section();
+        int row = placedSection.itemIndex() / anvillib$COLUMN_COUNT - scrollRow;
+        if (row < 0 || row >= anvillib$VISIBLE_ROW_COUNT) return;
+        int bannerWidth = section.bannerLength() * anvillib$CELL_SIZE;
+        int bannerX = this.leftPos + anvillib$GRID_LEFT - 1;
+        int bannerY = this.topPos + anvillib$GRID_TOP + row * anvillib$CELL_SIZE - 1;
+        graphics.pose().pushPose();
+        try {
+            graphics.pose().translate(0.0F, 0.0F, anvillib$BANNER_Z);
+            graphics.blit(
+                section.bannerTexture(),
+                bannerX,
+                bannerY,
+                0,
+                0,
+                bannerWidth,
+                anvillib$CELL_SIZE,
+                bannerWidth,
+                anvillib$CELL_SIZE
+            );
+            this.anvillib$renderBannerText(graphics, section, bannerX, bannerY, bannerWidth);
+        } finally {
+            graphics.pose().popPose();
+        }
+        if (mouseX >= bannerX && mouseX < bannerX + bannerWidth
+            && mouseY >= bannerY && mouseY < bannerY + anvillib$CELL_SIZE) {
+            this.anvillib$hoveredSection = section;
+        }
+    }
+
+    @Unique
+    private void anvillib$renderBannerText(
+        GuiGraphics graphics,
+        CreativeTabSection section,
+        int bannerX,
+        int bannerY,
+        int bannerWidth
+    ) {
+        int maxTextWidth = bannerWidth - anvillib$TEXT_PADDING * 2;
+        int textWidth = this.font.width(section.text());
+        if (textWidth == 0) return;
+        float textScale = Math.min(1.0F, (float) maxTextWidth / textWidth);
+        int scaledTextWidth = (int) Math.ceil(textWidth * textScale);
+        int scaledTextHeight = (int) Math.ceil(this.font.lineHeight * textScale);
+        int textX = bannerX + (bannerWidth - scaledTextWidth) / 2;
+        int textY = bannerY + (anvillib$CELL_SIZE - scaledTextHeight) / 2 + 1;
+        if ((section.textBackgroundColor() >>> 24) != 0) {
+            graphics.fill(
+                textX - anvillib$TEXT_PADDING,
+                textY - 1,
+                textX + scaledTextWidth + anvillib$TEXT_PADDING,
+                textY + scaledTextHeight,
+                section.textBackgroundColor()
+            );
+        }
+        graphics.pose().pushPose();
+        try {
+            graphics.pose().translate(textX, textY, 0.0F);
+            graphics.pose().scale(textScale, textScale, 1.0F);
+            graphics.drawString(this.font, section.text(), 0, 0, 0xFFFFFFFF, true);
+        } finally {
+            graphics.pose().popPose();
+        }
+    }
+}

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/CreativeTabSection.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/CreativeTabSection.java
@@ -1,0 +1,78 @@
+package dev.anvilcraft.lib.v2.registrum.util;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
+import java.util.Objects;
+
+public record CreativeTabSection(
+    int bannerLength,
+    ResourceLocation bannerTexture,
+    Component text,
+    int textBackgroundColor,
+    List<Component> tooltip
+) {
+    public static final int MIN_BANNER_LENGTH = 1;
+    public static final int MAX_BANNER_LENGTH = 9;
+    public static final int DEFAULT_BANNER_LENGTH = 3;
+
+    public CreativeTabSection {
+        if (bannerLength < MIN_BANNER_LENGTH || bannerLength > MAX_BANNER_LENGTH) {
+            throw new IllegalArgumentException("Banner length must be between 1 and 9");
+        }
+        bannerTexture = Objects.requireNonNull(bannerTexture, "bannerTexture");
+        text = Objects.requireNonNull(text, "text");
+        tooltip = List.copyOf(tooltip);
+    }
+
+    public static Builder builder(ResourceLocation bannerTexture) {
+        return new Builder(bannerTexture);
+    }
+
+    public static final class Builder {
+        private final ResourceLocation bannerTexture;
+        private int bannerLength = DEFAULT_BANNER_LENGTH;
+        private Component text = Component.empty();
+        private int textBackgroundColor = 0x00000000;
+        private List<Component> tooltip = List.of();
+
+        private Builder(ResourceLocation bannerTexture) {
+            this.bannerTexture = Objects.requireNonNull(bannerTexture, "bannerTexture");
+        }
+
+        public Builder bannerLength(int bannerLength) {
+            this.bannerLength = bannerLength;
+            return this;
+        }
+
+        public Builder text(Component text) {
+            this.text = Objects.requireNonNull(text, "text");
+            return this;
+        }
+
+        public Builder textBackgroundColor(int textBackgroundColor) {
+            this.textBackgroundColor = textBackgroundColor;
+            return this;
+        }
+
+        public Builder tooltip(Component... tooltip) {
+            return this.tooltip(List.of(tooltip));
+        }
+
+        public Builder tooltip(List<Component> tooltip) {
+            this.tooltip = List.copyOf(tooltip);
+            return this;
+        }
+
+        public CreativeTabSection build() {
+            return new CreativeTabSection(
+                this.bannerLength,
+                this.bannerTexture,
+                this.text,
+                this.textBackgroundColor,
+                this.tooltip
+            );
+        }
+    }
+}

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/CreativeTabSections.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/CreativeTabSections.java
@@ -1,0 +1,118 @@
+package dev.anvilcraft.lib.v2.registrum.util;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+public final class CreativeTabSections implements CreativeModeTab.Output {
+    private static final int COLUMN_COUNT = 9;
+    private static final Map<ResourceLocation, Layout> LAYOUTS = new ConcurrentHashMap<>();
+    private static final Map<ResourceLocation, List<PlacedSection>> PLACEMENTS = new ConcurrentHashMap<>();
+
+    private final CreativeModeTab.ItemDisplayParameters parameters;
+    private final CreativeModeTab.Output output;
+    private final List<SectionStart> sections = new ArrayList<>();
+    private int parentItemCount;
+
+    private CreativeTabSections(
+        CreativeModeTab.ItemDisplayParameters parameters,
+        CreativeModeTab.Output output
+    ) {
+        this.parameters = parameters;
+        this.output = output;
+    }
+
+    public static void build(
+        ResourceLocation tabId,
+        CreativeModeTab.ItemDisplayParameters parameters,
+        CreativeModeTab.Output output,
+        Consumer<CreativeTabSections> contents
+    ) {
+        Objects.requireNonNull(tabId, "tabId");
+        Objects.requireNonNull(parameters, "parameters");
+        Objects.requireNonNull(output, "output");
+        Objects.requireNonNull(contents, "contents");
+        CreativeTabSections sectionOutput = new CreativeTabSections(parameters, output);
+        contents.accept(sectionOutput);
+        if (sectionOutput.sections.isEmpty()) {
+            LAYOUTS.remove(tabId);
+            PLACEMENTS.remove(tabId);
+            return;
+        }
+        LAYOUTS.put(tabId, new Layout(List.copyOf(sectionOutput.sections)));
+    }
+
+    public void section(CreativeTabSection section, Consumer<CreativeTabSections> contents) {
+        this.sections.add(new SectionStart(Objects.requireNonNull(section, "section"), this.parentItemCount));
+        Objects.requireNonNull(contents, "contents").accept(this);
+    }
+
+    @Override
+    public void accept(ItemStack stack, CreativeModeTab.TabVisibility visibility) {
+        this.output.accept(stack, visibility);
+        if (visibility != CreativeModeTab.TabVisibility.SEARCH_TAB_ONLY
+            && stack.isItemEnabled(this.parameters.enabledFeatures())) {
+            this.parentItemCount++;
+        }
+    }
+
+    public static Collection<ItemStack> arrange(ResourceLocation tabId, Collection<ItemStack> items) {
+        Layout layout = LAYOUTS.get(tabId);
+        if (layout == null) return items;
+        List<ItemStack> original = List.copyOf(items);
+        List<ItemStack> arranged = new ArrayList<>(original.size());
+        List<PlacedSection> placedSections = new ArrayList<>(layout.sections().size());
+        int originalIndex = 0;
+
+        for (int index = 0; index < layout.sections().size(); index++) {
+            SectionStart sectionStart = layout.sections().get(index);
+            int sectionItemIndex = Math.max(
+                originalIndex,
+                Math.min(sectionStart.itemIndex(), original.size())
+            );
+            arranged.addAll(original.subList(originalIndex, sectionItemIndex));
+            int nextSectionItemIndex = index + 1 < layout.sections().size()
+                ? Math.max(
+                    sectionItemIndex,
+                    Math.min(layout.sections().get(index + 1).itemIndex(), original.size())
+                )
+                : original.size();
+            if (nextSectionItemIndex > sectionItemIndex) {
+                while (arranged.size() % COLUMN_COUNT != 0) {
+                    arranged.add(ItemStack.EMPTY);
+                }
+                int bannerIndex = arranged.size();
+                for (int cell = 0; cell < sectionStart.section().bannerLength(); cell++) {
+                    arranged.add(ItemStack.EMPTY);
+                }
+                placedSections.add(new PlacedSection(sectionStart.section(), bannerIndex));
+            }
+            originalIndex = sectionItemIndex;
+        }
+
+        arranged.addAll(original.subList(originalIndex, original.size()));
+        PLACEMENTS.put(tabId, List.copyOf(placedSections));
+        return List.copyOf(arranged);
+    }
+
+    public static List<PlacedSection> placedSections(ResourceLocation tabId) {
+        return PLACEMENTS.getOrDefault(tabId, List.of());
+    }
+
+    public record PlacedSection(CreativeTabSection section, int itemIndex) {
+    }
+
+    private record Layout(List<SectionStart> sections) {
+    }
+
+    private record SectionStart(CreativeTabSection section, int itemIndex) {
+    }
+}

--- a/module.registrum/src/main/resources/anvillib_registrum.mixins.json
+++ b/module.registrum/src/main/resources/anvillib_registrum.mixins.json
@@ -1,12 +1,14 @@
 {
   "required": true,
   "minVersion": "0.8",
-  "package": "dev.anvilcraft.lib.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "package": "dev.anvilcraft.lib.v2.registrum.mixin",
+  "compatibilityLevel": "JAVA_21",
   "refmap": "anvillib.refmap.json",
   "mixins": [
+    "CreativeModeTabMixin"
   ],
   "client": [
+    "client.CreativeModeInventoryScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
- 新增创造模式标签分区配置与布局工具
- 为 CreativeTabBuilder 提供分区物品展示 API
- 支持在创造物品栏渲染横幅、文本和悬停提示