### PR TITLE
fix

### DIFF
--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/mixin/client/CreativeModeInventoryScreenMixin.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/mixin/client/CreativeModeInventoryScreenMixin.java
@@ -5,6 +5,7 @@ import dev.anvilcraft.lib.v2.registrum.client.gui.CreativeVariantPickerOverlay;
 import dev.anvilcraft.lib.v2.registrum.util.CreativeTabSection;
 import dev.anvilcraft.lib.v2.registrum.util.CreativeTabSections;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -398,6 +399,8 @@ abstract class CreativeModeInventoryScreenMixin
         int bannerWidth = section.bannerLength() * anvillib$CELL_SIZE;
         int bannerX = this.leftPos + anvillib$GRID_LEFT - 1;
         int bannerY = this.topPos + anvillib$GRID_TOP + row * anvillib$CELL_SIZE - 1;
+        boolean hovered = mouseX >= bannerX && mouseX < bannerX + bannerWidth
+            && mouseY >= bannerY && mouseY < bannerY + anvillib$CELL_SIZE;
         graphics.pose().pushPose();
         try {
             graphics.pose().translate(0.0F, 0.0F, anvillib$BANNER_Z);
@@ -412,12 +415,11 @@ abstract class CreativeModeInventoryScreenMixin
                 bannerWidth,
                 anvillib$CELL_SIZE
             );
-            this.anvillib$renderBannerText(graphics, section, bannerX, bannerY, bannerWidth);
+            this.anvillib$renderBannerText(graphics, section, bannerX, bannerY, bannerWidth, hovered);
         } finally {
             graphics.pose().popPose();
         }
-        if (mouseX >= bannerX && mouseX < bannerX + bannerWidth
-            && mouseY >= bannerY && mouseY < bannerY + anvillib$CELL_SIZE) {
+        if (hovered) {
             this.anvillib$hoveredSection = section;
         }
     }
@@ -428,32 +430,48 @@ abstract class CreativeModeInventoryScreenMixin
         CreativeTabSection section,
         int bannerX,
         int bannerY,
-        int bannerWidth
+        int bannerWidth,
+        boolean hovered
     ) {
         int maxTextWidth = bannerWidth - anvillib$TEXT_PADDING * 2;
         int textWidth = this.font.width(section.text());
         if (textWidth == 0) return;
-        float textScale = Math.min(1.0F, (float) maxTextWidth / textWidth);
-        int scaledTextWidth = (int) Math.ceil(textWidth * textScale);
-        int scaledTextHeight = (int) Math.ceil(this.font.lineHeight * textScale);
-        int textX = bannerX + (bannerWidth - scaledTextWidth) / 2;
-        int textY = bannerY + (anvillib$CELL_SIZE - scaledTextHeight) / 2 + 1;
+        int textLeft = bannerX + anvillib$TEXT_PADDING;
+        int textRight = bannerX + bannerWidth - anvillib$TEXT_PADDING;
+        int textX = switch (section.textAlignment()) {
+            case LEFT -> textLeft;
+            case CENTER -> textLeft + (maxTextWidth - textWidth) / 2;
+            case RIGHT -> textRight - textWidth;
+        };
+        int textY = bannerY + (anvillib$CELL_SIZE - this.font.lineHeight) / 2 + 1;
+        boolean overflowing = textWidth > maxTextWidth;
         if ((section.textBackgroundColor() >>> 24) != 0) {
             graphics.fill(
-                textX - anvillib$TEXT_PADDING,
+                overflowing ? bannerX : textX - anvillib$TEXT_PADDING,
                 textY - 1,
-                textX + scaledTextWidth + anvillib$TEXT_PADDING,
-                textY + scaledTextHeight,
+                overflowing ? bannerX + bannerWidth : textX + textWidth + anvillib$TEXT_PADDING,
+                textY + this.font.lineHeight,
                 section.textBackgroundColor()
             );
         }
-        graphics.pose().pushPose();
+        if (hovered && overflowing) {
+            AbstractWidget.renderScrollingString(
+                graphics,
+                this.font,
+                section.text(),
+                textLeft,
+                bannerY,
+                textRight,
+                bannerY + anvillib$CELL_SIZE,
+                0xFFFFFFFF
+            );
+            return;
+        }
+        graphics.enableScissor(textLeft, bannerY, textRight, bannerY + anvillib$CELL_SIZE);
         try {
-            graphics.pose().translate(textX, textY, 0.0F);
-            graphics.pose().scale(textScale, textScale, 1.0F);
-            graphics.drawString(this.font, section.text(), 0, 0, 0xFFFFFFFF, true);
+            graphics.drawString(this.font, section.text(), textX, textY, 0xFFFFFFFF, true);
         } finally {
-            graphics.pose().popPose();
+            graphics.disableScissor();
         }
     }
 }

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/CreativeTabSection.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/CreativeTabSection.java
@@ -11,7 +11,8 @@ public record CreativeTabSection(
     ResourceLocation bannerTexture,
     Component text,
     int textBackgroundColor,
-    List<Component> tooltip
+    List<Component> tooltip,
+    TextAlignment textAlignment
 ) {
     public static final int MIN_BANNER_LENGTH = 1;
     public static final int MAX_BANNER_LENGTH = 9;
@@ -24,6 +25,17 @@ public record CreativeTabSection(
         bannerTexture = Objects.requireNonNull(bannerTexture, "bannerTexture");
         text = Objects.requireNonNull(text, "text");
         tooltip = List.copyOf(tooltip);
+        textAlignment = Objects.requireNonNull(textAlignment, "textAlignment");
+    }
+
+    public CreativeTabSection(
+        int bannerLength,
+        ResourceLocation bannerTexture,
+        Component text,
+        int textBackgroundColor,
+        List<Component> tooltip
+    ) {
+        this(bannerLength, bannerTexture, text, textBackgroundColor, tooltip, TextAlignment.CENTER);
     }
 
     public static Builder builder(ResourceLocation bannerTexture) {
@@ -36,6 +48,7 @@ public record CreativeTabSection(
         private Component text = Component.empty();
         private int textBackgroundColor = 0x00000000;
         private List<Component> tooltip = List.of();
+        private TextAlignment textAlignment = TextAlignment.CENTER;
 
         private Builder(ResourceLocation bannerTexture) {
             this.bannerTexture = Objects.requireNonNull(bannerTexture, "bannerTexture");
@@ -56,6 +69,11 @@ public record CreativeTabSection(
             return this;
         }
 
+        public Builder textAlignment(TextAlignment textAlignment) {
+            this.textAlignment = Objects.requireNonNull(textAlignment, "textAlignment");
+            return this;
+        }
+
         public Builder tooltip(Component... tooltip) {
             return this.tooltip(List.of(tooltip));
         }
@@ -71,8 +89,15 @@ public record CreativeTabSection(
                 this.bannerTexture,
                 this.text,
                 this.textBackgroundColor,
-                this.tooltip
+                this.tooltip,
+                this.textAlignment
             );
         }
+    }
+
+    public enum TextAlignment {
+        LEFT,
+        CENTER,
+        RIGHT
     }
 }

--- a/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/CreativeVariantPickerRegistry.java
+++ b/module.registrum/src/main/java/dev/anvilcraft/lib/v2/registrum/util/CreativeVariantPickerRegistry.java
@@ -44,6 +44,7 @@ public final class CreativeVariantPickerRegistry {
         DyeColor.PINK
     );
     private static final Map<Item, List<VariantGroup>> GROUPS = new ConcurrentHashMap<>();
+    private static volatile BooleanSupplier vanillaColorVariantPickerEnabled = () -> false;
     private static volatile boolean colorFamiliesDiscovered;
 
     private CreativeVariantPickerRegistry() {
@@ -52,6 +53,17 @@ public final class CreativeVariantPickerRegistry {
     /** 返回叠加层使用的稳定颜色顺序。 */
     public static List<DyeColor> colorOrder() {
         return COLOR_ORDER;
+    }
+
+    /**
+     * 设置原版独立十六色物品组是否折叠为创造物品栏选择器，默认不折叠
+     *
+     * <p>实现模组可传入客户端配置字段的读取器，配置重载后的值会在下次构建创造标签时读取</p>
+     *
+     * @param enabled 返回 {@code true} 时折叠完整的原版十六色物品组
+     */
+    public static void setVanillaColorVariantPickerEnabled(BooleanSupplier enabled) {
+        vanillaColorVariantPickerEnabled = Objects.requireNonNull(enabled, "enabled");
     }
 
     /** 注册由独立物品组成的变体组，例如原版式的彩色方块。 */
@@ -203,10 +215,14 @@ public final class CreativeVariantPickerRegistry {
                 List<ItemStack> variants = COLOR_ORDER.stream()
                     .map(color -> new ItemStack(family.get(color)))
                     .toList();
-                registerStacks(variants);
+                registerStacks(CreativeVariantPickerRegistry::isVanillaColorVariantPickerEnabled, variants);
             }
             colorFamiliesDiscovered = true;
         }
+    }
+
+    private static boolean isVanillaColorVariantPickerEnabled() {
+        return vanillaColorVariantPickerEnabled.getAsBoolean();
     }
 
     private record FamilyKey(String namespace, String basePath) {


### PR DESCRIPTION
移除全部文字缩放，超宽文本保持 MC 原始像素字体并裁剪
鼠标悬浮超宽 banner 时，使用原版横向滚动显示完整文字
新增 LEFT、CENTER、RIGHT 对齐，默认 CENTER
保留旧的五参数 CreativeTabSection 构造函数，已有调用仍默认居中