### PR TITLE
feat(recipe): 为配方查找增加基于方块约束的搜索树剪枝

### DIFF
--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/util/InWorldRecipeManager.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/util/InWorldRecipeManager.java
@@ -220,9 +220,15 @@ public class InWorldRecipeManager {
      */
     private static final class PrunePlan {
         /**
-         * 共享判定节点，按注册顺序排列以保证确定性的读取次序
+         * 共享判定节点，仅用于注册时按 {@link NodeKey} 去重；解析时按 {@link #groups} 遍历
          */
         private final Map<NodeKey, JudgeNode> nodes = new LinkedHashMap<>();
+
+        /**
+         * 按位置偏移分组的判定节点，按注册顺序排列以保证确定性的读取次序；
+         * 解析时每组只读取一次世界，组内节点共享该次读取
+         */
+        private final Map<Vec3, OffsetGroup> groups = new LinkedHashMap<>();
 
         /**
          * 配方槽位映射，用于解析时识别未经 {@link InWorldRecipeManager#register} 注册的配方并保守放行
@@ -243,9 +249,13 @@ public class InWorldRecipeManager {
         void add(RecipeHolder<InWorldRecipe> holder, List<BlockConstraint> constraints) {
             Slot slot = new Slot();
             for (BlockConstraint constraint : constraints) {
-                JudgeNode node = this.nodes.computeIfAbsent(
-                    new NodeKey(constraint.offset(), BlockSetKey.of(constraint.predicate().getBlocks())),
-                    key -> new JudgeNode(key, constraint.predicate()));
+                NodeKey key = new NodeKey(constraint.offset(), BlockSetKey.of(constraint.predicate().getBlocks()));
+                JudgeNode node = this.nodes.get(key);
+                if (node == null) {
+                    node = new JudgeNode(key, constraint.predicate());
+                    this.nodes.put(key, node);
+                    this.groups.computeIfAbsent(key.offset(), OffsetGroup::new).nodes.add(node);
+                }
                 node.edges.add(slot); // 建立节点到配方的连线
             }
             this.slotMap.put(holder, slot);
@@ -254,9 +264,9 @@ public class InWorldRecipeManager {
         /**
          * 解析当前上下文下的幸存候选配方
          * <p>
-         * 流程：逐节点判定一次实际方块状态 → 失效沿连线传播（一票否决）→
-         * 全部失效时立即返回 → 按候选集既有顺序收集幸存者并对未注册配方兜底放行。
-         * 相同 offset 的多个节点共享同一次世界读取。
+         * 流程：按 offset 分组逐组判定（每组一次世界读取，组内节点共享）→
+         * 失效沿连线传播（一票否决）→ 全部失效时立即返回 →
+         * 按候选集既有顺序收集幸存者并对未注册配方兜底放行。
          * 判定经 {@link BlockStatePredicate#cannotMatch} 进行：返回 true 时对应谓词必然失败，
          * 否决健全；返回 false 时不做结论（属性与 NBT 条件留给完整匹配检查）
          * </p>
@@ -270,24 +280,20 @@ public class InWorldRecipeManager {
             InWorldRecipeContext ctx
         ) {
             try {
-                if (!this.nodes.isEmpty()) {
+                if (!this.groups.isEmpty()) {
                     int alive = this.slotMap.size();
                     // 存在未经注册直接写入候选集的配方时不做整体提前终止，保证其被保守放行
                     boolean fullyIndexed = this.slotMap.size() >= holders.size();
                     BlockCache cache = ctx.computeIfAbsent(BlockCache.BLOCK_CACHE);
-                    Map<Vec3, BlockState> states = new HashMap<>();
-                    for (JudgeNode node : this.nodes.values()) {
-                        Vec3 offset = node.key.offset();
-                        BlockState state = states.get(offset);
-                        if (state == null) {
-                            state = cache.getBlockState(BlockPos.containing(ctx.getPos().add(offset)));
-                            states.put(offset, state);
-                        }
-                        if (!node.judge.cannotMatch(state)) continue; // 节点判定通过
-                        // 节点失效：沿连线一票否决全部相连配方
-                        for (Slot edge : node.edges) {
-                            if (edge.fails++ == 0 && --alive == 0 && fullyIndexed) {
-                                return Collections.emptyList();
+                    for (OffsetGroup group : this.groups.values()) {
+                        BlockState state = cache.getBlockState(BlockPos.containing(ctx.getPos().add(group.offset)));
+                        for (JudgeNode node : group.nodes) {
+                            if (!node.judge.cannotMatch(state)) continue; // 节点判定通过
+                            // 节点失效：沿连线一票否决全部相连配方
+                            for (Slot edge : node.edges) {
+                                if (edge.fails++ == 0 && --alive == 0 && fullyIndexed) {
+                                    return Collections.emptyList();
+                                }
                             }
                         }
                     }
@@ -309,6 +315,30 @@ public class InWorldRecipeManager {
          */
         private void reset() {
             for (Slot slot : this.slotMap.values()) slot.fails = 0;
+        }
+    }
+
+    /**
+     * 位置偏移分组：同一归一化 offset 下的全部判定节点，共享一次世界读取
+     */
+    private static final class OffsetGroup {
+        /**
+         * 归一化后的位置偏移（即组内节点的 {@link NodeKey#offset}）
+         */
+        private final Vec3 offset;
+
+        /**
+         * 本偏移下的判定节点，按注册顺序排列
+         */
+        private final List<JudgeNode> nodes = new ArrayList<>();
+
+        /**
+         * 构造一个位置偏移分组
+         *
+         * @param offset 归一化后的位置偏移
+         */
+        private OffsetGroup(Vec3 offset) {
+            this.offset = offset;
         }
     }
 

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/util/InWorldRecipeManager.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/util/InWorldRecipeManager.java
@@ -2,15 +2,29 @@ package dev.anvilcraft.lib.v2.recipe.util;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.Iterables;
 import dev.anvilcraft.lib.v2.recipe.AnvilLibRecipe;
+import dev.anvilcraft.lib.v2.recipe.cache.BlockCache;
 import dev.anvilcraft.lib.v2.recipe.event.InWorldRecipeEvent;
 import dev.anvilcraft.lib.v2.recipe.InWorldRecipe;
+import dev.anvilcraft.lib.v2.recipe.predicate.IRecipePredicate;
+import dev.anvilcraft.lib.v2.recipe.predicate.block.HasBlockBase;
 import dev.anvilcraft.lib.v2.recipe.trigger.IRecipeTrigger;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderSet;
 import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -26,29 +40,97 @@ public class InWorldRecipeManager {
         .build();
 
     /**
+     * 配方方块剪枝约束缓存，键为配方持有者，随注册构建
+     * <p>
+     * 约束列表为空表示该配方不含可剪枝的方块约束，永远不会被剪枝
+     * </p>
+     */
+    private final Map<RecipeHolder<InWorldRecipe>, List<BlockConstraint>> blockConstraints = new HashMap<>();
+
+    /**
      * 构造一个新的世界内配方管理器，并注册一个默认配方
      */
     public InWorldRecipeManager() {
     }
 
     /**
-     * 注册一个世界内配方
+     * 注册一个世界内配方，并预提取其方块剪枝约束
      *
      * @param recipe 要注册的配方
      */
     public void register(RecipeHolder<InWorldRecipe> recipe) {
         recipeHolders.put(recipe.value().trigger(), recipe);
+        this.blockConstraints.put(recipe, InWorldRecipeManager.extractBlockConstraints(recipe.value()));
+    }
+
+    /**
+     * 从配方中提取方块剪枝约束
+     * <p>
+     * 仅提取限定了方块集合（blocks 非空）的 {@link HasBlockBase} 类谓词；
+     * 未限制方块的谓词不产生约束，所在配方不会被剪枝。
+     * 该提取假设继承 {@link HasBlockBase} 的谓词在 test 时按基类契约检查
+     * 其 offset 位置的方块状态是否满足 predicate 的方块限制
+     * </p>
+     *
+     * @param recipe 世界内配方
+     * @return 方块剪枝约束列表（不可变）
+     */
+    private static List<BlockConstraint> extractBlockConstraints(InWorldRecipe recipe) {
+        List<BlockConstraint> constraints = new ArrayList<>();
+        for (IRecipePredicate<?> predicate : Iterables.concat(recipe.nonConflicting(), recipe.conflicting())) {
+            if (!(predicate instanceof HasBlockBase<?> hasBlock)) continue;
+            HolderSet<Block> blocks = hasBlock.getPredicate().getBlocks();
+            if (blocks.size() == 0) continue; // 不限制对应位置的方块：不产生约束，禁止剪枝
+            constraints.add(new BlockConstraint(hasBlock.getOffset(), blocks));
+        }
+        return List.copyOf(constraints);
     }
 
     /**
      * 触发指定的配方触发器并执行匹配的配方
+     * <p>
+     * 先根据注册期预提取的方块约束批量失效所有不可能匹配的配方，
+     * 仅对幸存候选依次执行完整匹配
+     * </p>
      *
      * @param trigger 配方触发器
      * @param ctx     配方上下文
      */
     public void trigger(IRecipeTrigger trigger, InWorldRecipeContext ctx) {
         if (ctx.getLevel().isClientSide()) return;
-        for (RecipeHolder<InWorldRecipe> holder : recipeHolders.get(trigger)) {
+        Collection<RecipeHolder<InWorldRecipe>> holders = this.recipeHolders.get(trigger);
+        if (holders.isEmpty()) return;
+
+        BlockCache cache = null;
+        Map<Vec3, BlockState> states = null;
+        List<RecipeHolder<InWorldRecipe>> candidates = null;
+        for (RecipeHolder<InWorldRecipe> holder : holders) {
+            List<BlockConstraint> constraints = this.blockConstraints.get(holder);
+            boolean mayMatch = true;
+            if (constraints != null && !constraints.isEmpty()) {
+                if (cache == null) cache = ctx.computeIfAbsent(BlockCache.BLOCK_CACHE);
+                if (states == null) states = new HashMap<>();
+                for (BlockConstraint constraint : constraints) {
+                    Vec3 offset = constraint.offset();
+                    BlockState state = states.get(offset);
+                    if (state == null) {
+                        state = cache.getBlockState(BlockPos.containing(ctx.getPos().add(offset)));
+                        states.put(offset, state);
+                    }
+                    if (!state.is(constraint.blocks())) {
+                        mayMatch = false; // 对应位置的实际方块不可能满足约束，整体失效该配方
+                        break;
+                    }
+                }
+            }
+            if (mayMatch) {
+                if (candidates == null) candidates = new ArrayList<>();
+                candidates.add(holder);
+            }
+        }
+        if (candidates == null) return;
+
+        for (RecipeHolder<InWorldRecipe> holder : candidates) {
             InWorldRecipe recipe = holder.value();
             boolean accept = false;
             for (int i = 0; i < AnvilLibRecipe.CONFIG.inWorldRecipeMaxEfficiency; i++) {
@@ -73,5 +155,14 @@ public class InWorldRecipeManager {
      */
     public void trigger(Supplier<IRecipeTrigger> trigger, InWorldRecipeContext ctx) {
         this.trigger(trigger.get(), ctx);
+    }
+
+    /**
+     * 方块剪枝约束：配方在某相对位置对允许方块集合的限制
+     *
+     * @param offset 相对配方触发点的位置偏移
+     * @param blocks 允许的方块集合（提取时已保证非空）
+     */
+    private record BlockConstraint(Vec3 offset, HolderSet<Block> blocks) {
     }
 }

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/util/InWorldRecipeManager.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/util/InWorldRecipeManager.java
@@ -10,14 +10,17 @@ import dev.anvilcraft.lib.v2.recipe.event.InWorldRecipeEvent;
 import dev.anvilcraft.lib.v2.recipe.predicate.IRecipePredicate;
 import dev.anvilcraft.lib.v2.recipe.predicate.block.HasBlockBase;
 import dev.anvilcraft.lib.v2.recipe.trigger.IRecipeTrigger;
+import dev.anvilcraft.lib.v2.util.predicate.BlockStatePredicate;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,14 +45,20 @@ import java.util.function.Supplier;
 public class InWorldRecipeManager {
     /**
      * 配方排序器，与 {@link #recipeHolders} 候选集的排序保持一致，确保剪枝不改变执行顺序
+     * <p>
+     * 优先级相等时以配方 id 决胜：{@link IPrioritized#compareTo} 对同优先级的不同对象恒返回 1
+     * （不满足比较器对称性），追加确定性的 id 决胜以保证集合行为与遍历顺序确定
+     * </p>
      */
-    private static final Comparator<RecipeHolder<InWorldRecipe>> RECIPE_ORDER = Comparator.comparing(RecipeHolder::value);
+    private static final Comparator<RecipeHolder<InWorldRecipe>> RECIPE_ORDER = Comparator
+        .comparing(RecipeHolder<InWorldRecipe>::value)
+        .thenComparing(RecipeHolder::id);
 
     /**
      * 存储配方的映射表，键为配方触发器，值为配方集合
      */
-    public final Multimap<IRecipeTrigger, @NotNull RecipeHolder<InWorldRecipe>> recipeHolders = MultimapBuilder.hashKeys()
-        .<RecipeHolder<InWorldRecipe>>treeSetValues(RECIPE_ORDER)
+    public final Multimap<IRecipeTrigger, RecipeHolder<InWorldRecipe>> recipeHolders = MultimapBuilder.hashKeys()
+        .treeSetValues(RECIPE_ORDER)
         .build();
 
     /**
@@ -94,9 +103,8 @@ public class InWorldRecipeManager {
         List<BlockConstraint> constraints = new ArrayList<>();
         for (IRecipePredicate<?> predicate : Iterables.concat(recipe.nonConflicting(), recipe.conflicting())) {
             if (!(predicate instanceof HasBlockBase<?> hasBlock)) continue;
-            HolderSet<Block> blocks = hasBlock.getPredicate().getBlocks();
-            if (blocks.size() == 0) continue; // 不限制对应位置的方块：不产生约束，禁止剪枝
-            constraints.add(new BlockConstraint(hasBlock.getOffset(), blocks));
+            if (hasBlock.getPredicate().getBlocks().size() == 0) continue; // 不限制对应位置的方块：不产生约束，禁止剪枝
+            constraints.add(new BlockConstraint(hasBlock.getOffset(), hasBlock.getPredicate()));
         }
         return List.copyOf(constraints);
     }
@@ -153,21 +161,55 @@ public class InWorldRecipeManager {
     }
 
     /**
-     * 方块剪枝约束：配方在某相对位置对允许方块集合的限制
+     * 方块剪枝约束：配方在某相对位置上的方块状态谓词
      *
-     * @param offset 相对配方触发点的位置偏移
-     * @param blocks 允许的方块集合（提取时已保证非空）
+     * @param offset    相对配方触发点的位置偏移
+     * @param predicate 方块状态谓词（提取时已保证其方块集合非空）
      */
-    private record BlockConstraint(Vec3 offset, HolderSet<Block> blocks) {
+    private record BlockConstraint(Vec3 offset, BlockStatePredicate predicate) {
     }
 
     /**
      * 共享判定节点的键：相同的位置偏移与方块集合限制合并为同一节点
+     * <p>
+     * 位置偏移在构造时归一化（-0.0 归为 0.0），避免数学上相同的偏移因浮点表示差异而无法合并
+     * </p>
      *
      * @param offset 相对配方触发点的位置偏移
-     * @param blocks 允许的方块集合（非空）
+     * @param blocks 允许方块集合的规范化键
      */
-    private record NodeKey(Vec3 offset, HolderSet<Block> blocks) {
+    private record NodeKey(Vec3 offset, BlockSetKey blocks) {
+        private NodeKey {
+            offset = new Vec3(
+                offset.x == 0 ? 0 : offset.x,
+                offset.y == 0 ? 0 : offset.y,
+                offset.z == 0 ? 0 : offset.z
+            );
+        }
+    }
+
+    /**
+     * 方块集合的规范化键：标签按其 {@link TagKey} 值相等合并，
+     * 直接集合按排序后的方块 id 列表值相等合并；
+     * 含无键 Holder 的集合无法规范化，以 {@link HolderSet} 实例身份兜底（不合并，仅降低共享率）
+     *
+     * @param key 规范化后的键（TagKey / 排序后的 ResourceLocation 列表 / HolderSet 实例）
+     */
+    private record BlockSetKey(Object key) {
+        private static BlockSetKey of(HolderSet<Block> blocks) {
+            return blocks.unwrap().map(
+                BlockSetKey::new,
+                holders -> {
+                    List<ResourceLocation> ids = new ArrayList<>(holders.size());
+                    for (Holder<Block> holder : holders) {
+                        if (holder.unwrapKey().isEmpty()) return new BlockSetKey(blocks); // 无键 Holder：实例身份兜底
+                        ids.add(holder.unwrapKey().orElseThrow().location());
+                    }
+                    ids.sort(null);
+                    return new BlockSetKey(List.copyOf(ids));
+                }
+            );
+        }
     }
 
     /**
@@ -184,6 +226,11 @@ public class InWorldRecipeManager {
 
         /**
          * 配方槽位映射，用于解析时识别未经 {@link InWorldRecipeManager#register} 注册的配方并保守放行
+         * <p>
+         * 当前不存在配方移除路径，本映射与 {@link #nodes} 只增不减；
+         * 若未来支持移除配方，必须同步清理二者，否则 alive 初值偏大会使提前终止静默失效
+         * （正确性不受影响，仅损失性能）
+         * </p>
          */
         private final Map<RecipeHolder<InWorldRecipe>, Slot> slotMap = new HashMap<>();
 
@@ -197,7 +244,8 @@ public class InWorldRecipeManager {
             Slot slot = new Slot();
             for (BlockConstraint constraint : constraints) {
                 JudgeNode node = this.nodes.computeIfAbsent(
-                    new NodeKey(constraint.offset(), constraint.blocks()), JudgeNode::new);
+                    new NodeKey(constraint.offset(), BlockSetKey.of(constraint.predicate().getBlocks())),
+                    key -> new JudgeNode(key, constraint.predicate()));
                 node.edges.add(slot); // 建立节点到配方的连线
             }
             this.slotMap.put(holder, slot);
@@ -208,7 +256,9 @@ public class InWorldRecipeManager {
          * <p>
          * 流程：逐节点判定一次实际方块状态 → 失效沿连线传播（一票否决）→
          * 全部失效时立即返回 → 按候选集既有顺序收集幸存者并对未注册配方兜底放行。
-         * 相同 offset 的多个节点共享同一次世界读取
+         * 相同 offset 的多个节点共享同一次世界读取。
+         * 判定经 {@link BlockStatePredicate#cannotMatch} 进行：返回 true 时对应谓词必然失败，
+         * 否决健全；返回 false 时不做结论（属性与 NBT 条件留给完整匹配检查）
          * </p>
          *
          * @param holders 该触发器下的全部配方持有者（含可能绕过注册的直接写入）
@@ -219,37 +269,39 @@ public class InWorldRecipeManager {
             Collection<RecipeHolder<InWorldRecipe>> holders,
             InWorldRecipeContext ctx
         ) {
-            if (!this.nodes.isEmpty()) {
-                int alive = this.slotMap.size();
-                // 存在未经注册直接写入候选集的配方时不做整体提前终止，保证其被保守放行
-                boolean fullyIndexed = this.slotMap.size() >= holders.size();
-                BlockCache cache = ctx.computeIfAbsent(BlockCache.BLOCK_CACHE);
-                Map<Vec3, BlockState> states = new HashMap<>();
-                for (JudgeNode node : this.nodes.values()) {
-                    Vec3 offset = node.key.offset();
-                    BlockState state = states.get(offset);
-                    if (state == null) {
-                        state = cache.getBlockState(BlockPos.containing(ctx.getPos().add(offset)));
-                        states.put(offset, state);
-                    }
-                    if (state.is(node.key.blocks())) continue; // 节点判定通过
-                    // 节点失效：沿连线一票否决全部相连配方
-                    for (Slot edge : node.edges) {
-                        if (edge.fails++ == 0 && --alive == 0 && fullyIndexed) {
-                            this.reset();
-                            return Collections.emptyList();
+            try {
+                if (!this.nodes.isEmpty()) {
+                    int alive = this.slotMap.size();
+                    // 存在未经注册直接写入候选集的配方时不做整体提前终止，保证其被保守放行
+                    boolean fullyIndexed = this.slotMap.size() >= holders.size();
+                    BlockCache cache = ctx.computeIfAbsent(BlockCache.BLOCK_CACHE);
+                    Map<Vec3, BlockState> states = new HashMap<>();
+                    for (JudgeNode node : this.nodes.values()) {
+                        Vec3 offset = node.key.offset();
+                        BlockState state = states.get(offset);
+                        if (state == null) {
+                            state = cache.getBlockState(BlockPos.containing(ctx.getPos().add(offset)));
+                            states.put(offset, state);
+                        }
+                        if (!node.judge.cannotMatch(state)) continue; // 节点判定通过
+                        // 节点失效：沿连线一票否决全部相连配方
+                        for (Slot edge : node.edges) {
+                            if (edge.fails++ == 0 && --alive == 0 && fullyIndexed) {
+                                return Collections.emptyList();
+                            }
                         }
                     }
                 }
+                List<RecipeHolder<InWorldRecipe>> candidates = new ArrayList<>();
+                for (RecipeHolder<InWorldRecipe> holder : holders) {
+                    Slot slot = this.slotMap.get(holder);
+                    // 未建立索引的配方保守放行；已索引的仅当无任何约束节点失效时保留
+                    if (slot == null || slot.fails == 0) candidates.add(holder);
+                }
+                return candidates;
+            } finally {
+                this.reset(); // 复位计数（含异常路径），等待下次触发
             }
-            List<RecipeHolder<InWorldRecipe>> candidates = new ArrayList<>();
-            for (RecipeHolder<InWorldRecipe> holder : holders) {
-                Slot slot = this.slotMap.get(holder);
-                // 未建立索引的配方保守放行；已索引的仅当无任何约束节点失效时保留
-                if (slot == null || slot.fails == 0) candidates.add(holder);
-            }
-            this.reset(); // 复位计数，等待下次触发
-            return candidates;
         }
 
         /**
@@ -265,9 +317,15 @@ public class InWorldRecipeManager {
      */
     private static final class JudgeNode {
         /**
-         * 节点键：位置偏移与允许方块集合
+         * 节点键：位置偏移与允许方块集合的规范化键
          */
         private final NodeKey key;
+
+        /**
+         * 判定用代表谓词：合并到本节点的所有谓词方块集合相同，
+         * 任取其一经 {@link BlockStatePredicate#cannotMatch} 判定即可
+         */
+        private final BlockStatePredicate judge;
 
         /**
          * 连线到的配方槽位
@@ -277,10 +335,12 @@ public class InWorldRecipeManager {
         /**
          * 构造一个判定节点
          *
-         * @param key 节点键
+         * @param key   节点键
+         * @param judge 判定用代表谓词
          */
-        private JudgeNode(NodeKey key) {
+        private JudgeNode(NodeKey key, BlockStatePredicate judge) {
             this.key = key;
+            this.judge = judge;
         }
     }
 

--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/util/InWorldRecipeManager.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/util/InWorldRecipeManager.java
@@ -1,12 +1,12 @@
 package dev.anvilcraft.lib.v2.recipe.util;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
-import com.google.common.collect.Iterables;
 import dev.anvilcraft.lib.v2.recipe.AnvilLibRecipe;
+import dev.anvilcraft.lib.v2.recipe.InWorldRecipe;
 import dev.anvilcraft.lib.v2.recipe.cache.BlockCache;
 import dev.anvilcraft.lib.v2.recipe.event.InWorldRecipeEvent;
-import dev.anvilcraft.lib.v2.recipe.InWorldRecipe;
 import dev.anvilcraft.lib.v2.recipe.predicate.IRecipePredicate;
 import dev.anvilcraft.lib.v2.recipe.predicate.block.HasBlockBase;
 import dev.anvilcraft.lib.v2.recipe.trigger.IRecipeTrigger;
@@ -21,31 +21,41 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 /**
  * 世界内配方管理器类，用于管理和触发世界内配方
- * 该类负责注册配方和根据触发器执行相应的配方
+ * <p>
+ * 该类负责注册配方和根据触发器执行相应的配方。
+ * 注册时为每个触发器构建 {@link PrunePlan} 剪枝计划：
+ * 相同位置偏移与方块集合限制的约束合并为共享判定节点，
+ * 触发查找时每个节点至多判定一次实际方块状态，
+ * 判定失败沿连线一票否决全部相连配方，全部失效时立即终止
+ * </p>
  */
 public class InWorldRecipeManager {
+    /**
+     * 配方排序器，与 {@link #recipeHolders} 候选集的排序保持一致，确保剪枝不改变执行顺序
+     */
+    private static final Comparator<RecipeHolder<InWorldRecipe>> RECIPE_ORDER = Comparator.comparing(RecipeHolder::value);
+
     /**
      * 存储配方的映射表，键为配方触发器，值为配方集合
      */
     public final Multimap<IRecipeTrigger, @NotNull RecipeHolder<InWorldRecipe>> recipeHolders = MultimapBuilder.hashKeys()
-        .<RecipeHolder<InWorldRecipe>>treeSetValues(Comparator.comparing(RecipeHolder::value))
+        .<RecipeHolder<InWorldRecipe>>treeSetValues(RECIPE_ORDER)
         .build();
 
     /**
-     * 配方方块剪枝约束缓存，键为配方持有者，随注册构建
-     * <p>
-     * 约束列表为空表示该配方不含可剪枝的方块约束，永远不会被剪枝
-     * </p>
+     * 各触发器对应的方块约束剪枝计划，随注册逐步构建
      */
-    private final Map<RecipeHolder<InWorldRecipe>, List<BlockConstraint>> blockConstraints = new HashMap<>();
+    private final Map<IRecipeTrigger, PrunePlan> prunePlans = new HashMap<>();
 
     /**
      * 构造一个新的世界内配方管理器，并注册一个默认配方
@@ -54,20 +64,25 @@ public class InWorldRecipeManager {
     }
 
     /**
-     * 注册一个世界内配方，并预提取其方块剪枝约束
+     * 注册一个世界内配方，并将其方块约束并入对应触发器的剪枝计划
+     * <p>
+     * 直接写入 {@link #recipeHolders} 而绕过此方法的配方不会进入剪枝计划，
+     * 查找时将被保守放行（不做剪枝），行为与未引入剪枝前一致
+     * </p>
      *
      * @param recipe 要注册的配方
      */
     public void register(RecipeHolder<InWorldRecipe> recipe) {
         recipeHolders.put(recipe.value().trigger(), recipe);
-        this.blockConstraints.put(recipe, InWorldRecipeManager.extractBlockConstraints(recipe.value()));
+        this.prunePlans.computeIfAbsent(recipe.value().trigger(), trigger -> new PrunePlan())
+            .add(recipe, InWorldRecipeManager.extractBlockConstraints(recipe.value()));
     }
 
     /**
      * 从配方中提取方块剪枝约束
      * <p>
      * 仅提取限定了方块集合（blocks 非空）的 {@link HasBlockBase} 类谓词；
-     * 未限制方块的谓词不产生约束，所在配方不会被剪枝。
+     * 未限制对应位置方块的谓词不产生约束，所在配方不会被剪枝。
      * 该提取假设继承 {@link HasBlockBase} 的谓词在 test 时按基类契约检查
      * 其 offset 位置的方块状态是否满足 predicate 的方块限制
      * </p>
@@ -89,8 +104,8 @@ public class InWorldRecipeManager {
     /**
      * 触发指定的配方触发器并执行匹配的配方
      * <p>
-     * 先根据注册期预提取的方块约束批量失效所有不可能匹配的配方，
-     * 仅对幸存候选依次执行完整匹配
+     * 先经剪枝计划批量失效所有不可能匹配的配方，仅对幸存候选依次执行完整匹配；
+     * 幸存候选的顺序与未引入剪枝时的遍历顺序完全一致
      * </p>
      *
      * @param trigger 配方触发器
@@ -101,34 +116,14 @@ public class InWorldRecipeManager {
         Collection<RecipeHolder<InWorldRecipe>> holders = this.recipeHolders.get(trigger);
         if (holders.isEmpty()) return;
 
-        BlockCache cache = null;
-        Map<Vec3, BlockState> states = null;
-        List<RecipeHolder<InWorldRecipe>> candidates = null;
-        for (RecipeHolder<InWorldRecipe> holder : holders) {
-            List<BlockConstraint> constraints = this.blockConstraints.get(holder);
-            boolean mayMatch = true;
-            if (constraints != null && !constraints.isEmpty()) {
-                if (cache == null) cache = ctx.computeIfAbsent(BlockCache.BLOCK_CACHE);
-                if (states == null) states = new HashMap<>();
-                for (BlockConstraint constraint : constraints) {
-                    Vec3 offset = constraint.offset();
-                    BlockState state = states.get(offset);
-                    if (state == null) {
-                        state = cache.getBlockState(BlockPos.containing(ctx.getPos().add(offset)));
-                        states.put(offset, state);
-                    }
-                    if (!state.is(constraint.blocks())) {
-                        mayMatch = false; // 对应位置的实际方块不可能满足约束，整体失效该配方
-                        break;
-                    }
-                }
-            }
-            if (mayMatch) {
-                if (candidates == null) candidates = new ArrayList<>();
-                candidates.add(holder);
-            }
+        PrunePlan plan = this.prunePlans.get(trigger);
+        List<RecipeHolder<InWorldRecipe>> candidates;
+        if (plan == null) {
+            candidates = new ArrayList<>(holders); // 无剪枝计划：全量放行
+        } else {
+            candidates = plan.resolve(holders, ctx);
+            if (candidates.isEmpty()) return;
         }
-        if (candidates == null) return;
 
         for (RecipeHolder<InWorldRecipe> holder : candidates) {
             InWorldRecipe recipe = holder.value();
@@ -164,5 +159,138 @@ public class InWorldRecipeManager {
      * @param blocks 允许的方块集合（提取时已保证非空）
      */
     private record BlockConstraint(Vec3 offset, HolderSet<Block> blocks) {
+    }
+
+    /**
+     * 共享判定节点的键：相同的位置偏移与方块集合限制合并为同一节点
+     *
+     * @param offset 相对配方触发点的位置偏移
+     * @param blocks 允许的方块集合（非空）
+     */
+    private record NodeKey(Vec3 offset, HolderSet<Block> blocks) {
+    }
+
+    /**
+     * 单个触发器的剪枝计划：判定节点与配方槽位构成的二部连线结构
+     * <p>
+     * 仅在服务端主线程访问，不做同步
+     * </p>
+     */
+    private static final class PrunePlan {
+        /**
+         * 共享判定节点，按注册顺序排列以保证确定性的读取次序
+         */
+        private final Map<NodeKey, JudgeNode> nodes = new LinkedHashMap<>();
+
+        /**
+         * 配方槽位映射，用于解析时识别未经 {@link InWorldRecipeManager#register} 注册的配方并保守放行
+         */
+        private final Map<RecipeHolder<InWorldRecipe>, Slot> slotMap = new HashMap<>();
+
+        /**
+         * 向计划中添加一个配方及其方块约束连线
+         *
+         * @param holder      配方持有者
+         * @param constraints 方块剪枝约束列表
+         */
+        void add(RecipeHolder<InWorldRecipe> holder, List<BlockConstraint> constraints) {
+            Slot slot = new Slot();
+            for (BlockConstraint constraint : constraints) {
+                JudgeNode node = this.nodes.computeIfAbsent(
+                    new NodeKey(constraint.offset(), constraint.blocks()), JudgeNode::new);
+                node.edges.add(slot); // 建立节点到配方的连线
+            }
+            this.slotMap.put(holder, slot);
+        }
+
+        /**
+         * 解析当前上下文下的幸存候选配方
+         * <p>
+         * 流程：逐节点判定一次实际方块状态 → 失效沿连线传播（一票否决）→
+         * 全部失效时立即返回 → 按候选集既有顺序收集幸存者并对未注册配方兜底放行。
+         * 相同 offset 的多个节点共享同一次世界读取
+         * </p>
+         *
+         * @param holders 该触发器下的全部配方持有者（含可能绕过注册的直接写入）
+         * @param ctx     配方上下文
+         * @return 幸存候选列表，顺序与候选集遍历顺序一致；全部失效时为空列表
+         */
+        List<RecipeHolder<InWorldRecipe>> resolve(
+            Collection<RecipeHolder<InWorldRecipe>> holders,
+            InWorldRecipeContext ctx
+        ) {
+            if (!this.nodes.isEmpty()) {
+                int alive = this.slotMap.size();
+                // 存在未经注册直接写入候选集的配方时不做整体提前终止，保证其被保守放行
+                boolean fullyIndexed = this.slotMap.size() >= holders.size();
+                BlockCache cache = ctx.computeIfAbsent(BlockCache.BLOCK_CACHE);
+                Map<Vec3, BlockState> states = new HashMap<>();
+                for (JudgeNode node : this.nodes.values()) {
+                    Vec3 offset = node.key.offset();
+                    BlockState state = states.get(offset);
+                    if (state == null) {
+                        state = cache.getBlockState(BlockPos.containing(ctx.getPos().add(offset)));
+                        states.put(offset, state);
+                    }
+                    if (state.is(node.key.blocks())) continue; // 节点判定通过
+                    // 节点失效：沿连线一票否决全部相连配方
+                    for (Slot edge : node.edges) {
+                        if (edge.fails++ == 0 && --alive == 0 && fullyIndexed) {
+                            this.reset();
+                            return Collections.emptyList();
+                        }
+                    }
+                }
+            }
+            List<RecipeHolder<InWorldRecipe>> candidates = new ArrayList<>();
+            for (RecipeHolder<InWorldRecipe> holder : holders) {
+                Slot slot = this.slotMap.get(holder);
+                // 未建立索引的配方保守放行；已索引的仅当无任何约束节点失效时保留
+                if (slot == null || slot.fails == 0) candidates.add(holder);
+            }
+            this.reset(); // 复位计数，等待下次触发
+            return candidates;
+        }
+
+        /**
+         * 复位全部配方槽位的失效计数
+         */
+        private void reset() {
+            for (Slot slot : this.slotMap.values()) slot.fails = 0;
+        }
+    }
+
+    /**
+     * 共享判定节点：聚合相同 (offset, blocks) 约束的判定与受影响配方连线
+     */
+    private static final class JudgeNode {
+        /**
+         * 节点键：位置偏移与允许方块集合
+         */
+        private final NodeKey key;
+
+        /**
+         * 连线到的配方槽位
+         */
+        private final List<Slot> edges = new ArrayList<>();
+
+        /**
+         * 构造一个判定节点
+         *
+         * @param key 节点键
+         */
+        private JudgeNode(NodeKey key) {
+            this.key = key;
+        }
+    }
+
+    /**
+     * 配方槽位：记录配方在当前触发中的失效计数
+     */
+    private static final class Slot {
+        /**
+         * 已失效的约束边数，0 表示尚无任何约束节点判定失败（即存活）
+         */
+        private int fails;
     }
 }

--- a/module.test/build.gradle
+++ b/module.test/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     implementation project(":anvillib-registrum-neoforge-1.21.1")
     implementation project(":anvillib-util-neoforge-1.21.1")
     implementation project(":anvillib-wheel-neoforge-1.21.1")
+    implementation("dev.dubhe:anvilcraft-neoforge-1.21.1:1.6.0+snapshot.2184") { transitive = false }
 }
 
 tasks.withType(JavaExec).configureEach {

--- a/module.util/src/main/java/dev/anvilcraft/lib/v2/util/predicate/BlockStatePredicate.java
+++ b/module.util/src/main/java/dev/anvilcraft/lib/v2/util/predicate/BlockStatePredicate.java
@@ -27,8 +27,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.StateHolder;
 import net.minecraft.world.level.block.state.properties.Property;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -129,7 +129,7 @@ public class BlockStatePredicate {
     }
 
     public boolean testWithoutEntity(BlockState state) {
-        if (this.blocks.size() > 0 && !state.is(this.blocks)) return false;
+        if (this.cannotMatch(state)) return false;
         if (this.properties.isEmpty()) return true;
         boolean orSuccess = false;
         for (List<PropertyMatcher> matchers : this.properties) {
@@ -145,6 +145,20 @@ public class BlockStatePredicate {
             }
         }
         return orSuccess;
+    }
+
+    /**
+     * 判断仅凭方块状态（不检查属性与 NBT）是否即可确定不匹配
+     * <p>
+     * 用于保守剪枝：返回 {@code true} 时 {@link #test} 与 {@link #testWithoutEntity}
+     * 对该状态必然失败；返回 {@code false} 不代表匹配成功（属性与 NBT 条件未检查）
+     * </p>
+     *
+     * @param state 方块状态
+     * @return 是否可确定不匹配
+     */
+    public boolean cannotMatch(BlockState state) {
+        return this.blocks.size() > 0 && !state.is(this.blocks);
     }
 
     public boolean testEntity(LevelAccessor level, BlockState state, @Nullable BlockEntity entity) {
@@ -195,7 +209,7 @@ public class BlockStatePredicate {
         return !this.nbts.isEmpty();
     }
 
-    private List<BlockState> statesCache;
+    private @Nullable List<BlockState> statesCache;
 
     public List<BlockState> getStatesCache() {
         if (this.statesCache != null) return this.statesCache;


### PR DESCRIPTION
- InWorldRecipeManager 注册配方时预提取 HasBlockBase 谓词的方块约束（offset 与非空 blocks 集合）
- 触发查找时按相对位置批量去重读取实际方块状态，一次性失效所有不可能匹配的配方
- 未限制对应位置方块（blocks 为空）的谓词不产生约束，所在配方永不剪枝
- 候选集沿用既有优先级排序，完整匹配与执行循环语义不变