### PR TITLE
feat(rpc): 新增虚拟线程友好的同步阻塞调用 invokeSync

### DIFF
--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RPC.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RPC.java
@@ -2,6 +2,8 @@ package dev.anvilcraft.lib.v2.rpc;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -45,7 +47,9 @@ import java.util.concurrent.CompletableFuture;
  * }
  * }</pre>
  */
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@SuppressWarnings("unused")
 public final class RPC {
     /**
      * 调用无参方法。
@@ -672,10 +676,31 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的有返回值远程调用——显式声明当前线程允许阻塞。
+     *
+     * <p>调用方显式声明 {@code allowNonVirtual=true} 时（如平台线程池、Netty 线程等已知可阻塞的线程），
+     * 跳过对"非虚拟线程"的警告。仍请勿在 Minecraft 主线程等必须非阻塞的线程调用。</p>
+     *
+     * @param allowNonVirtual 是否允许在非虚拟线程阻塞等待
+     */
+    @ApiStatus.Experimental
+    public static <R> R invokeSync(RpcTarget target, boolean allowNonVirtual, RpcFunctionRef.F0<R> methodRef) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef);
+    }
+
+    /**
      * 同步阻塞形态的单参调用。
      */
     public static <R, A> R invokeSync(RpcTarget target, RpcFunctionRef.F1<R, A> methodRef, A a) {
         return invokeSyncDispatch(target, methodRef, a);
+    }
+
+    /**
+     * 同步阻塞形态的单参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A> R invokeSync(RpcTarget target, boolean allowNonVirtual, RpcFunctionRef.F1<R, A> methodRef, A a) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a);
     }
 
     /**
@@ -686,10 +711,33 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的双参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B> R invokeSync(RpcTarget target, boolean allowNonVirtual, RpcFunctionRef.F2<R, A, B> methodRef, A a, B b) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b);
+    }
+
+    /**
      * 同步阻塞形态的三参调用。
      */
     public static <R, A, B, C> R invokeSync(RpcTarget target, RpcFunctionRef.F3<R, A, B, C> methodRef, A a, B b, C c) {
         return invokeSyncDispatch(target, methodRef, a, b, c);
+    }
+
+    /**
+     * 同步阻塞形态的三参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F3<R, A, B, C> methodRef,
+        A a,
+        B b,
+        C c
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c);
     }
 
     /**
@@ -700,10 +748,51 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的四参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F4<R, A, B, C, D> methodRef,
+        A a,
+        B b,
+        C c,
+        D d
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d);
+    }
+
+    /**
      * 同步阻塞形态的五参调用。
      */
-    public static <R, A, B, C, D, E> R invokeSync(RpcTarget target, RpcFunctionRef.F5<R, A, B, C, D, E> methodRef, A a, B b, C c, D d, E e) {
+    public static <R, A, B, C, D, E> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F5<R, A, B, C, D, E> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e
+    ) {
         return invokeSyncDispatch(target, methodRef, a, b, c, d, e);
+    }
+
+    /**
+     * 同步阻塞形态的五参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F5<R, A, B, C, D, E> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e);
     }
 
     /**
@@ -723,6 +812,24 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的六参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F6<R, A, B, C, D, E, F> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f);
+    }
+
+    /**
      * 同步阻塞形态的七参调用。
      */
     public static <R, A, B, C, D, E, F, G> R invokeSync(
@@ -737,6 +844,25 @@ public final class RPC {
         G g
     ) {
         return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g);
+    }
+
+    /**
+     * 同步阻塞形态的七参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F7<R, A, B, C, D, E, F, G> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g);
     }
 
     /**
@@ -758,6 +884,26 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的八参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F8<R, A, B, C, D, E, F, G, H> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h);
+    }
+
+    /**
      * 同步阻塞形态的九参调用。
      */
     public static <R, A, B, C, D, E, F, G, H, I> R invokeSync(
@@ -774,6 +920,27 @@ public final class RPC {
         I i
     ) {
         return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i);
+    }
+
+    /**
+     * 同步阻塞形态的九参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H, I> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F9<R, A, B, C, D, E, F, G, H, I> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h, i);
     }
 
     /**
@@ -797,6 +964,28 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的十参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H, I, J> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F10<R, A, B, C, D, E, F, G, H, I, J> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h, i, j);
+    }
+
+    /**
      * 同步阻塞形态的十一参调用。
      */
     public static <R, A, B, C, D, E, F, G, H, I, J, K> R invokeSync(
@@ -815,6 +1004,29 @@ public final class RPC {
         K k
     ) {
         return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k);
+    }
+
+    /**
+     * 同步阻塞形态的十一参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H, I, J, K> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F11<R, A, B, C, D, E, F, G, H, I, J, K> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h, i, j, k);
     }
 
     /**
@@ -840,6 +1052,30 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的十二参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F12<R, A, B, C, D, E, F, G, H, I, J, K, L> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h, i, j, k, l);
+    }
+
+    /**
      * 同步阻塞形态的十三参调用。
      */
     public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M> R invokeSync(
@@ -860,6 +1096,31 @@ public final class RPC {
         M m
     ) {
         return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m);
+    }
+
+    /**
+     * 同步阻塞形态的十三参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F13<R, A, B, C, D, E, F, G, H, I, J, K, L, M> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l,
+        M m
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m);
     }
 
     /**
@@ -887,6 +1148,32 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的十四参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M, N> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F14<R, A, B, C, D, E, F, G, H, I, J, K, L, M, N> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l,
+        M m,
+        N n
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m, n);
+    }
+
+    /**
      * 同步阻塞形态的十五参调用。
      */
     public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> R invokeSync(
@@ -909,6 +1196,33 @@ public final class RPC {
         O o
     ) {
         return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o);
+    }
+
+    /**
+     * 同步阻塞形态的十五参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F15<R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l,
+        M m,
+        N n,
+        O o
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o);
     }
 
     /**
@@ -938,6 +1252,34 @@ public final class RPC {
     }
 
     /**
+     * 同步阻塞形态的十六参调用——显式声明当前线程允许阻塞。
+     */
+    @ApiStatus.Experimental
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> R invokeSync(
+        RpcTarget target,
+        boolean allowNonVirtual,
+        RpcFunctionRef.F16<R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l,
+        M m,
+        N n,
+        O o,
+        P p
+    ) {
+        return invokeSyncDispatchAllow(target, allowNonVirtual, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p);
+    }
+
+    /**
      * 同步阻塞形态的逃生口：按类与方法名发起有返回值的远程调用，参数个数不限。
      *
      * <p>与 {@link #invokeByName} 同理，失去对实参的编译期类型检查。阻塞直到收到响应或超时。</p>
@@ -951,11 +1293,15 @@ public final class RPC {
      */
     public static <R> R invokeSyncByName(RpcTarget target, Class<?> clazz, String methodName, Object... args) {
         Method method = RpcMethods.resolveByName(clazz, methodName);
-        return invokeSyncChecked(target, method, args);
+        return invokeSyncChecked(target, method, args, false);
     }
 
     private static <R> R invokeSyncDispatch(RpcTarget target, Serializable methodRef, Object... args) {
-        return invokeSyncChecked(target, LambdaResolver.resolve(methodRef), args);
+        return invokeSyncChecked(target, LambdaResolver.resolve(methodRef), args, false);
+    }
+
+    private static <R> R invokeSyncDispatchAllow(RpcTarget target, boolean allowNonVirtual, Serializable methodRef, Object... args) {
+        return invokeSyncChecked(target, LambdaResolver.resolve(methodRef), args, allowNonVirtual);
     }
 
     private static void dispatch(RpcTarget target, Serializable methodRef, Object... args) {
@@ -990,7 +1336,13 @@ public final class RPC {
 
     // ---- 同步阻塞形态（虚拟线程友好）----
 
-    private static <R> R invokeSyncChecked(RpcTarget target, Method method, Object[] args) {
+    private static <R> R invokeSyncChecked(RpcTarget target, Method method, Object[] args, boolean allowNonVirtual) {
+        if (!allowNonVirtual && !Thread.currentThread().isVirtual()) {
+            log.warn(
+                "RPC call to {} from non-virtual thread {}; this blocks the current thread until the response arrives",
+                method, Thread.currentThread().getName()
+            );
+        }
         if (method.getReturnType() == void.class) {
             throw new IllegalArgumentException("RPC method " + method + " returns void; use RPC.call instead");
         }

--- a/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RPC.java
+++ b/module.rpc/src/main/java/dev/anvilcraft/lib/v2/rpc/RPC.java
@@ -30,6 +30,20 @@ import java.util.concurrent.CompletableFuture;
  * // 服务端令某个客户端执行 Greetings.hello("world", 3)
  * RPC.call(RpcTarget.player(serverPlayer), Greetings::hello, "world", 3);
  * }</pre>
+ *
+ * <h2>同步阻塞调用（虚拟线程友好）</h2>
+ * <p>在虚拟线程中需要像本地方法一样直接取返回值时，用 {@link #invokeSync}（或
+ * {@link #invokeSyncByName}）：它在当前（虚拟）线程阻塞直到收到对端响应或超时，不占用平台线程、无需额外线程池。
+ * 请在虚拟线程中使用；在平台线程（如 Minecraft 主线程）中使用会阻塞该线程，需自行权衡。</p>
+ * <pre>{@code
+ * // 在虚拟线程中直接取返回值：阻塞等待期间不占用平台线程
+ * int sum;
+ * try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+ *     sum = executor.submit(() ->
+ *         RPC.invokeSync(RpcTarget.player(serverPlayer), RemoteApi::computeSum, 10, 32)
+ *     ).get();
+ * }
+ * }</pre>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RPC {
@@ -642,6 +656,308 @@ public final class RPC {
         return invokeChecked(target, method, args);
     }
 
+    /**
+     * 同步阻塞形态的有返回值远程调用：在（虚拟）线程内阻塞直到收到对端响应或超时。
+     *
+     * <p>在虚拟线程中使用时不要为结果创建额外线程或轮询——直接像本地方法一样取返回值即可，阻塞不消耗
+     * 平台线程。在平台线程（如 Minecraft 主线程）中使用会阻塞该线程，请自行权衡。</p>
+     *
+     * @param target    目标端
+     * @param methodRef 指向 {@link RemoteCallable} 静态方法的方法引用
+     * @param <R>       返回类型
+     * @return 收到的远程返回值
+     */
+    public static <R> R invokeSync(RpcTarget target, RpcFunctionRef.F0<R> methodRef) {
+        return invokeSyncDispatch(target, methodRef);
+    }
+
+    /**
+     * 同步阻塞形态的单参调用。
+     */
+    public static <R, A> R invokeSync(RpcTarget target, RpcFunctionRef.F1<R, A> methodRef, A a) {
+        return invokeSyncDispatch(target, methodRef, a);
+    }
+
+    /**
+     * 同步阻塞形态的双参调用。
+     */
+    public static <R, A, B> R invokeSync(RpcTarget target, RpcFunctionRef.F2<R, A, B> methodRef, A a, B b) {
+        return invokeSyncDispatch(target, methodRef, a, b);
+    }
+
+    /**
+     * 同步阻塞形态的三参调用。
+     */
+    public static <R, A, B, C> R invokeSync(RpcTarget target, RpcFunctionRef.F3<R, A, B, C> methodRef, A a, B b, C c) {
+        return invokeSyncDispatch(target, methodRef, a, b, c);
+    }
+
+    /**
+     * 同步阻塞形态的四参调用。
+     */
+    public static <R, A, B, C, D> R invokeSync(RpcTarget target, RpcFunctionRef.F4<R, A, B, C, D> methodRef, A a, B b, C c, D d) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d);
+    }
+
+    /**
+     * 同步阻塞形态的五参调用。
+     */
+    public static <R, A, B, C, D, E> R invokeSync(RpcTarget target, RpcFunctionRef.F5<R, A, B, C, D, E> methodRef, A a, B b, C c, D d, E e) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e);
+    }
+
+    /**
+     * 同步阻塞形态的六参调用。
+     */
+    public static <R, A, B, C, D, E, F> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F6<R, A, B, C, D, E, F> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f);
+    }
+
+    /**
+     * 同步阻塞形态的七参调用。
+     */
+    public static <R, A, B, C, D, E, F, G> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F7<R, A, B, C, D, E, F, G> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g);
+    }
+
+    /**
+     * 同步阻塞形态的八参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F8<R, A, B, C, D, E, F, G, H> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h);
+    }
+
+    /**
+     * 同步阻塞形态的九参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H, I> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F9<R, A, B, C, D, E, F, G, H, I> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i);
+    }
+
+    /**
+     * 同步阻塞形态的十参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H, I, J> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F10<R, A, B, C, D, E, F, G, H, I, J> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j);
+    }
+
+    /**
+     * 同步阻塞形态的十一参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H, I, J, K> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F11<R, A, B, C, D, E, F, G, H, I, J, K> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k);
+    }
+
+    /**
+     * 同步阻塞形态的十二参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F12<R, A, B, C, D, E, F, G, H, I, J, K, L> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k, l);
+    }
+
+    /**
+     * 同步阻塞形态的十三参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F13<R, A, B, C, D, E, F, G, H, I, J, K, L, M> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l,
+        M m
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m);
+    }
+
+    /**
+     * 同步阻塞形态的十四参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M, N> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F14<R, A, B, C, D, E, F, G, H, I, J, K, L, M, N> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l,
+        M m,
+        N n
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m, n);
+    }
+
+    /**
+     * 同步阻塞形态的十五参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F15<R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l,
+        M m,
+        N n,
+        O o
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o);
+    }
+
+    /**
+     * 同步阻塞形态的十六参调用。
+     */
+    public static <R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> R invokeSync(
+        RpcTarget target,
+        RpcFunctionRef.F16<R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> methodRef,
+        A a,
+        B b,
+        C c,
+        D d,
+        E e,
+        F f,
+        G g,
+        H h,
+        I i,
+        J j,
+        K k,
+        L l,
+        M m,
+        N n,
+        O o,
+        P p
+    ) {
+        return invokeSyncDispatch(target, methodRef, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p);
+    }
+
+    /**
+     * 同步阻塞形态的逃生口：按类与方法名发起有返回值的远程调用，参数个数不限。
+     *
+     * <p>与 {@link #invokeByName} 同理，失去对实参的编译期类型检查。阻塞直到收到响应或超时。</p>
+     *
+     * @param target     目标端
+     * @param clazz      目标方法所属类
+     * @param methodName 目标方法名（须唯一且为 {@link RemoteCallable} 静态方法）
+     * @param args       实参
+     * @param <R>        返回类型
+     * @return 收到的远程返回值
+     */
+    public static <R> R invokeSyncByName(RpcTarget target, Class<?> clazz, String methodName, Object... args) {
+        Method method = RpcMethods.resolveByName(clazz, methodName);
+        return invokeSyncChecked(target, method, args);
+    }
+
+    private static <R> R invokeSyncDispatch(RpcTarget target, Serializable methodRef, Object... args) {
+        return invokeSyncChecked(target, LambdaResolver.resolve(methodRef), args);
+    }
+
     private static void dispatch(RpcTarget target, Serializable methodRef, Object... args) {
         Method method = LambdaResolver.resolve(methodRef);
         sendChecked(target, method, args);
@@ -670,5 +986,21 @@ public final class RPC {
         target.send(RpcRequestPayload.encode(target.registry(), target.registryAccess(), callId, method, args));
         @SuppressWarnings("unchecked") CompletableFuture<R> typed = (CompletableFuture<R>) future;
         return typed;
+    }
+
+    // ---- 同步阻塞形态（虚拟线程友好）----
+
+    private static <R> R invokeSyncChecked(RpcTarget target, Method method, Object[] args) {
+        if (method.getReturnType() == void.class) {
+            throw new IllegalArgumentException("RPC method " + method + " returns void; use RPC.call instead");
+        }
+        if (method.getParameterCount() != args.length) {
+            throw new IllegalArgumentException("RPC method " + method + " expects " + method.getParameterCount() + " arguments, got " + args.length);
+        }
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        int callId = target.pending().register(method, future);
+        target.send(RpcRequestPayload.encode(target.registry(), target.registryAccess(), callId, method, args));
+        @SuppressWarnings("unchecked") R result = (R) future.join();
+        return result;
     }
 }

--- a/module.test/src/main/java/dev/anvilcraft/lib/v2/test/rpc/RpcTestCommands.java
+++ b/module.test/src/main/java/dev/anvilcraft/lib/v2/test/rpc/RpcTestCommands.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
  * <ul>
  *     <li>/rpctest basic - 基础调用测试</li>
  *     <li>/rpctest invoke - 有返回值调用测试</li>
+ *     <li>/rpctest invoke-sync - 同步阻塞（虚拟线程）调用测试</li>
  *     <li>/rpctest validator - 校验器测试</li>
  *     <li>/rpctest stress - 压力测试</li>
  *     <li>/rpctest all - 运行所有测试</li>
@@ -45,6 +46,12 @@ public class RpcTestCommands {
                 .then(Commands.literal("invoke")
                     .executes(context -> {
                         runInvokeTest(context.getSource());
+                        return 1;
+                    })
+                )
+                .then(Commands.literal("invoke-sync")
+                    .executes(context -> {
+                        runInvokeSyncTest(context.getSource());
                         return 1;
                     })
                 )
@@ -140,6 +147,44 @@ public class RpcTestCommands {
         } catch (Exception e) {
             source.sendFailure(Component.literal("Invoke test failed: " + e.getMessage()));
             LOGGER.error("Invoke test failed", e);
+        }
+    }
+
+    private static void runInvokeSyncTest(CommandSourceStack source) {
+        if (!(source.getEntity() instanceof ServerPlayer player)) {
+            source.sendFailure(Component.literal("This command must be run by a player"));
+            return;
+        }
+
+        source.sendSuccess(() -> Component.literal("Running invoke-sync RPC test (virtual threads)..."), true);
+        TestRpcMethods.clearLog();
+        RpcTarget target = RpcTarget.player(player);
+
+        // 同步阻塞形态设计用于虚拟线程：阻塞等待期间不占用平台线程，RPC 响应仍在主线程兑现。
+        try {
+            Thread.ofVirtual().name("AnvilLib-RpcInvokeSyncTest").factory().newThread(() -> {
+                try {
+                    int intResult = RPC.invokeSync(target, TestRpcMethods::returnInt);
+                    source.sendSuccess(() -> Component.literal("invokeSync int: " + intResult), false);
+
+                    String stringResult = RPC.invokeSync(target, TestRpcMethods::returnString);
+                    source.sendSuccess(() -> Component.literal("invokeSync string: " + stringResult), false);
+
+                    int sum = RPC.invokeSync(target, TestRpcMethods::computeSum, 10, 32);
+                    source.sendSuccess(() -> Component.literal("invokeSync sum: " + sum), false);
+
+                    BlockPos pos = RPC.invokeSync(target, TestRpcMethods::returnCustomType, 5, 10, 15);
+                    source.sendSuccess(() -> Component.literal("invokeSync BlockPos: " + pos), false);
+
+                    source.sendSuccess(() -> Component.literal("invoke-sync test completed."), true);
+                } catch (Throwable e) {
+                    source.sendFailure(Component.literal("invoke-sync test failed: " + e));
+                    LOGGER.error("invoke-sync test failed", e);
+                }
+            }).start();
+        } catch (Exception e) {
+            source.sendFailure(Component.literal("invoke-sync test failed to start: " + e.getMessage()));
+            LOGGER.error("invoke-sync test failed to start", e);
         }
     }
 
@@ -244,9 +289,10 @@ public class RpcTestCommands {
 
         scheduleTest(0, () -> runBasicTest(source));
         scheduleTest(20, () -> runInvokeTest(source));
-        scheduleTest(40, () -> runValidatorTest(source));
-        scheduleTest(60, () -> runStressTest(source));
-        scheduleTest(80, () ->
+        scheduleTest(40, () -> runInvokeSyncTest(source));
+        scheduleTest(60, () -> runValidatorTest(source));
+        scheduleTest(80, () -> runStressTest(source));
+        scheduleTest(100, () ->
             source.sendSuccess(() -> Component.literal("All tests completed!"), true)
         );
     }


### PR DESCRIPTION
- 新增 RPC.invokeSync 系列（0~16 参 + invokeSyncByName），在（虚拟）线程内阻塞等待对端响应，直接返回结果
- 复用既有 RpcPendingCalls 登记与超时机制，不引入额外线程池或依赖
- 保持原有 CompletableFuture invoke 形态不变，回调继续走 ForkJoinPool.commonPool / 调用方显式 executor
- module.test 新增 /rpctest invoke-sync 命令，在虚拟线程中验证同步调用
- 新增 invokeSync(target, allowNonVirtual, ref, args...) 0~16 参全部重载，由调用方显式声明是否允许在非虚拟线程阻塞
- 全部 allowNonVirtual 重载标注 @ApiStatus.Experimental，与原有默认警告版本共存