### PR TITLE
Fix crash on executing the SaveComponentToTag predicate function to recipe items 修复对配方物品执行 SaveComponentToTag 谓词函数时发生崩溃的问题

### DIFF
--- a/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/predicate/item/HasItemBase.java
+++ b/module.recipe/src/main/java/dev/anvilcraft/lib/v2/recipe/predicate/item/HasItemBase.java
@@ -6,16 +6,16 @@ import dev.anvilcraft.lib.v2.codec.StreamCodecUtil;
 import dev.anvilcraft.lib.v2.recipe.AnvilLibRecipe;
 import dev.anvilcraft.lib.v2.recipe.cache.ItemCache;
 import dev.anvilcraft.lib.v2.recipe.cache.item.ICacheInput;
-import dev.anvilcraft.lib.v2.util.predicate.IItemStackPredicate;
 import dev.anvilcraft.lib.v2.recipe.predicate.IRecipePredicate;
 import dev.anvilcraft.lib.v2.recipe.predicate.function.IPredicateFunction;
 import dev.anvilcraft.lib.v2.recipe.util.InWorldRecipeContext;
 import dev.anvilcraft.lib.v2.recipe.util.InWorldRecipeData;
+import dev.anvilcraft.lib.v2.util.predicate.IItemStackPredicate;
 import lombok.Getter;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.List;
@@ -76,8 +76,9 @@ public abstract class HasItemBase<T extends HasItemBase<T, P>, P extends IItemSt
         ICacheInput item1 = this.getItem(context);
         item1.apply(itemStack -> {
             for (IPredicateFunction<?> function : this.functions) {
-                IPredicateFunction<ItemStack> function1 = (IPredicateFunction<ItemStack>) function;
-                itemStack = function1.apply(context, itemStack);
+                // TODO: This cast is unsafe. Refactor in the future?
+                IPredicateFunction<ItemStackTemplate> function1 = (IPredicateFunction<ItemStackTemplate>) function;
+                itemStack = function1.apply(context, ItemStackTemplate.fromNonEmptyStack(itemStack)).create();
             }
         });
     }


### PR DESCRIPTION
由于先前 `SaveComponentToTag` 类从实现 `IPredicateFunction<ItemStack>` 接口改为了实现 `IPredicateFunction<ItemStackTemplate>` 接口，而 `HasItemBase.accept` 方法中的强制类型转换没有同步更改，导致对配方物品执行 `SaveComponentToTag` 谓词函数时抛出 `ClassCastException` 异常导致崩溃。该 PR 修复了上述问题。

另外，建议今后重构此处逻辑，避免使用 unsafe casting。

Fixes Anvil-Dev/AnvilCraft#4453