### PR TITLE
修复轮盘顺时针切换至正上方选区延迟的问题

### DIFF
--- a/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/component/WheelWidget.java
+++ b/module.wheel/src/main/java/dev/anvilcraft/lib/v2/wheel/client/gui/component/WheelWidget.java
@@ -630,9 +630,11 @@ public class WheelWidget extends AbstractWidget {
         double rotation = cursorPos.x < 0 ? Math.PI - rot : Math.PI + rot;
         this.mouseAngleRad = (float) (rotation % (Math.PI * 2));
         for (WheelSection section : this.sections) {
-            if ((
-                section.angleStart > section.angleEnd && rotation >= section.angleStart || rotation >= section.angleStart && rotation <= section.angleEnd
-            ) && section.selectable) {
+            // 跨越 0° 的扇区由圆周末尾与开头两段组成。
+            boolean containsRotation = section.angleStart > section.angleEnd
+                ? rotation >= section.angleStart || rotation <= section.angleEnd
+                : rotation >= section.angleStart && rotation <= section.angleEnd;
+            if (containsRotation && section.selectable) {
                 this.currentAngle = section.angle;
                 this.setCurrentSectionIndex(this.sections.indexOf(section));
                 break;


### PR DESCRIPTION
- 补齐跨越 0° 的扇区命中判定，鼠标从左上方进入正上方选区时立即切换，无需转到 0°